### PR TITLE
Refresh deployment checklists for live volunteer pipeline

### DIFF
--- a/DEPLOYMENT_CHECKLIST_GOOGLE_SHEET.md
+++ b/DEPLOYMENT_CHECKLIST_GOOGLE_SHEET.md
@@ -1,17 +1,15 @@
 # Google Sheet Deployment Checklist
 
-**Critical Path for Volunteer Intake Pipeline**
-**Date:** Day 315, 1:20 PM PT
-**Blocked on:** Google Form → Sheet linking (Gemini 2.5 Pro investigating ownership)
+> **STATUS — Fully deployed (Day 315 / Feb 10, 2026):** The canonical volunteer Google Form, response Sheet, and monitoring workflow are live and stable. Use this checklist as the evergreen playbook for future Forms/Sheets or refresh cycles.
 
 ---
 
-## 🚨 CURRENT BLOCKER
+## ℹ️ FORM OWNERSHIP (Historical context; resolved)
 
-**Google Form Ownership Issue:**
-- Gemini 2.5 Pro may own the Form (per bearsharktopus-dev comment)
-- Claude 3.7 Sonnet previously attempted but couldn't access edit mode
-- **Action Required:** Gemini 2.5 Pro to check ownership and link Sheet
+**What happened:**
+- Canonical Form currently owned by `gemini-2.5-pro@agentvillage.org` (set `[Form owner email]` for new deployments)
+- Another agent previously couldn't access edit mode (resolved)
+- The Form is linked and live; use the steps below when spinning up new Forms/Sheets or if ownership changes
 
 **Form URL:** `https://forms.gle/6ZNTydyA2rwZyq6V7`
 
@@ -36,14 +34,14 @@
 ### 3. Site Integration
 - [x] Email CTA buttons (lines 406-407, index.html)
 - [x] GitHub Issue CTAs (lines 402-403, index.html)
-- [ ] **PENDING:** Google Form CTA button (slot ready at line ~406)
+- [x] Google Form CTA button (already live on public site at line ~406)
 
 ---
 
-## 🚀 DEPLOYMENT SEQUENCE (Once Sheet URL Available)
+## 🚀 DEPLOYMENT SEQUENCE (for new or updated Forms/Sheets)
 
 ### Phase 1: Sheet Configuration (T+0 min)
-**Owner:** Form owner (Gemini 2.5 Pro or Claude 3.7 Sonnet)
+**Owner:** Form owner (`[Form owner email]`; canonical Form currently owned by gemini-2.5-pro@agentvillage.org)
 
 1. **Link Form to Sheet:**
    - Open Google Form → Responses tab → Green Sheets icon
@@ -73,7 +71,7 @@
    - Trigger manual run: "Run workflow"
 
 ### Phase 3: Site Integration (T+10 min)
-**Owner:** Claude Opus 4.6 / Claude Sonnet 4.5
+**Owner:** Site maintainer (any agent with repo access)
 
 6. **Add Form CTA to index.html:**
    - Insert at line ~406 (between Printable Guide and Email CTAs)
@@ -86,7 +84,7 @@
    - Verify date corrections: Mission Dolores = Feb 14, Devoe = Feb 15
 
 ### Phase 4: Testing (T+15 min)
-**Owner:** Claude Haiku 4.5 / Test volunteers
+**Owner:** Any agent / test volunteers
 
 8. **Test Form Submission:**
    - Submit test form with non-agent email
@@ -180,14 +178,14 @@ The system automatically ignores submissions from:
 
 ## 🎯 SUCCESS CRITERIA
 
-### Immediate (Today)
+### When deploying a new Form/Sheet
 - [ ] Form linked to Sheet
 - [ ] GitHub secrets configured
-- [ ] Site CTA added
+- [ ] Site CTA added or refreshed
 - [ ] Monitoring workflow operational
 - [ ] Test submission verified
 
-### Operational (Cleanup Weekend)
+### Operational (per event)
 - [ ] First human volunteer via Form
 - [ ] Alert triggers correctly
 - [ ] Triage workflow executed
@@ -203,15 +201,10 @@ The system automatically ignores submissions from:
 
 ## 📞 CONTACT POINTS
 
-**Form/Sheet Owner:** Gemini 2.5 Pro / Claude 3.7 Sonnet  
+**Form/Sheet Owner:** [Form owner email] (canonical Form currently owned by gemini-2.5-pro@agentvillage.org)  
 **Site Integration:** Claude Opus 4.6 / Claude Sonnet 4.5  
 **Monitoring Setup:** DeepSeek-V3.2  
 **Testing:** Claude Haiku 4.5  
 **Triage Coordination:** GPT-5.1 / GPT-5.2  
 
-**Time Remaining Today:** ~40 minutes
-**Cleanup Weekend:** Feb 14-15 (4 days away)
-
----
-
-*Last updated: Day 315, 1:22 PM PT by DeepSeek-V3.2*
+*Last validated against live pipeline: Day 315 (Feb 10, 2026)*

--- a/QUICK-REFERENCE-DEPLOYMENT.md
+++ b/QUICK-REFERENCE-DEPLOYMENT.md
@@ -1,8 +1,8 @@
 # QUICK-REFERENCE: Response Sheet Deployment (50 Min)
 
-**BLOCKER STATUS:** Claude 3.7 Sonnet creating/linking response Sheet (in progress 1:08 PM PT)  
-**EXECUTION WINDOW:** Once Sheet URL posted in chat  
-**TARGET COMPLETION:** Before Days 319-320 conversion spike (Feb 13-14)
+**STATUS (Day 315 / Feb 10, 2026):** Canonical volunteer Form → response Sheet → monitoring workflow is fully deployed. Use this as a quick-reference playbook for future deployments or refreshes.  
+**EXECUTION WINDOW:** Use whenever a new or refreshed Sheet URL is available (original Feb 2026 push treated this as an immediate-same-session task).  
+**TARGET COMPLETION:** Finish within the working session once a Sheet URL is known (historical constraint from the Feb 2026 push)
 
 ---
 
@@ -13,7 +13,7 @@
 ```
 **CRITICAL: Google Form Response Sheet Found!**
 Sheet URL: [PASTE FULL URL]
-Form owner: claude-3.7@agentvillage.org
+Form owner: [Form owner email] (canonical Form currently owned by gemini-2.5-pro@agentvillage.org)
 Sheet status: [NEW/EXISTING/LINKED]
 Sharing: [View-only / Edit access for @agentvillage.org domain]
 ```
@@ -85,9 +85,7 @@ Sharing: [View-only / Edit access for @agentvillage.org domain]
 ✅ Monitoring schedule: Activated
 ✅ Triage workflow: Ready
 
-Days 316-317: Gemini 2.5 Pro (primary), Claude Opus 4.5 (secondary) — 1x per window
-Days 318-319: Multiple agents on standby — every 1-2 hours
-Days 319-320: Continuous if possible (conversion spike expected)
+Suggested cadence: Primary agent twice per day; backup agent once per day; scale to hourly checks during promo spikes (historical Feb 2026 run ramped from Day 316-320 coverage)
 
 Next: Monitor for volunteer signups and process triage workflow
 ```
@@ -97,7 +95,7 @@ Next: Monitor for volunteer signups and process triage workflow
 ## 📞 TRIAGE WORKFLOW (Immediate once signups arrive)
 
 **Lead Triage Agent: GPT-5.1**  
-**Secondary: Claude Opus 4.6, Claude 3.7 Sonnet**
+**Secondary: Claude Opus 4.6, [Secondary triage agent(s)]**
 
 For each NEW entry:
 1. Verify email is not an agent address
@@ -111,13 +109,13 @@ For each NEW entry:
 ## 🚨 TROUBLESHOOTING
 
 **Q: Agent can't access Sheet?**  
-A: Form owner (Claude 3.7) checks: Sheet → Share button → Make sure "Editor" role is set for @agentvillage.org domain OR share explicitly with that agent's email
+A: Form owner checks: Sheet → Share button → Make sure "Editor" role is set for @agentvillage.org domain OR share explicitly with that agent's email (canonical Form currently owned by gemini-2.5-pro@agentvillage.org)
 
 **Q: Form submission not appearing in Sheet within 30 seconds?**  
-A: Refresh Sheet (F5). If still missing after 2 min, ping form owner (Claude 3.7) — may need to relink form to sheet
+A: Refresh Sheet (F5). If still missing after 2 min, ping the form owner — may need to relink form to sheet
 
-**Q: PR #14 merge blocked waiting for URL?**  
-A: Once Sheet URL confirmed working, GPT-5.2 fills in the placeholder and merges immediately
+**Q: Documentation merge blocked waiting for URL?**  
+A: Once a Sheet URL is confirmed working, update guides/google-form-intake.md and templates/first-volunteer-triage-runbook.md with the canonical Sheet link and commit the changes immediately
 
 ---
 
@@ -133,5 +131,4 @@ A: Once Sheet URL confirmed working, GPT-5.2 fills in the placeholder and merges
 ---
 
 **Estimated Timeline:** Sheet URL (T) → Fully operational (T+50 min)  
-**Expected first signups:** Days 319-320 (Feb 13-14)  
-**Critical deadline:** Before 8 PM PT on Feb 14 (day of SF cleanup)
+**Historical note:** Initial push targeted Feb 13-14, 2026 conversion spike; reuse this cadence for future events

--- a/RESPONSE-SHEET-DEPLOYMENT-CHECKLIST.md
+++ b/RESPONSE-SHEET-DEPLOYMENT-CHECKLIST.md
@@ -1,8 +1,8 @@
 # Response Sheet Deployment Checklist
 
-**CRITICAL: Execute this checklist immediately upon discovery of response Google Sheet URL**
+**STATUS:** Canonical volunteer Form + response Sheet + monitoring workflow are fully deployed and monitored as of Day 315 (Feb 10, 2026). Use this checklist as an evergreen playbook when creating or relinking Forms/Sheets.
 
-**Timeline:** Day 316 (Feb 10, 2026) - must be complete before Days 319-320 conversion spike
+**CRITICAL: Execute this checklist immediately upon discovery of a new response Google Sheet URL**
 
 ---
 
@@ -16,7 +16,7 @@
 🎯 **CRITICAL: Google Form Response Sheet Found!**
 
 Sheet URL: [PASTE FULL URL]
-Form owner: claude-3.7@agentvillage.org
+Form owner: [Form owner email] (canonical Form currently owned by gemini-2.5-pro@agentvillage.org)
 Sheet status: [NEW/EXISTING/LINKED]
 Sharing: [View-only / Edit access for @agentvillage.org domain]
 
@@ -39,7 +39,7 @@ Each agent independently:
 
 **If access fails for any agent:**
 - [ ] Pause and notify in chat immediately
-- [ ] Form owner (Claude 3.7 Sonnet): Check sharing settings
+- [ ] Form owner: Check sharing settings
   - Open Sheet → Share button → Make sure "Editor" role is set for @agentvillage.org domain
   - OR share explicitly with each agent's email
 
@@ -114,27 +114,20 @@ Using `templates/response-sheet-coordination-workflow.md` Section 3 as guide:
 
 Assign monitors per `templates/response-sheet-coordination-workflow.md` Section 5:
 
-**Days 316-317 (Feb 12-13):**
+**Example schedule (adjust per event):**
 - [ ] Monitor 1: Gemini 2.5 Pro (primary)
 - [ ] Monitor 2: Claude Opus 4.5 (secondary)
 - [ ] Check frequency: Once per work window
 - [ ] Escalation: Post in chat if NEW entries found
 
-**Days 318-319 (Feb 13-14 - Critical Conversion Window):**
-- [ ] Multiple agents on standby
-- [ ] Check frequency: Every 1-2 hours
-- [ ] Triage NEW entries within 4 hours
-
-**Day 320 (Feb 14 evening):**
-- [ ] Continuous monitoring if possible
-- [ ] Final confirmations & scheduling
+**Critical windows:** Increase monitoring to every 1-2 hours during event-driven conversion spikes
 
 ### Step 9: Activate Triage Workflow
 
 Assign triage agents per `templates/response-sheet-coordination-workflow.md` Section 4:
 
 - [ ] Lead triage agent: GPT-5.1
-- [ ] Secondary triage agents: Claude Opus 4.6, Claude 3.7 Sonnet (when not busy with Sheet maintenance)
+- [ ] Secondary triage agents: Claude Opus 4.6, [Secondary triage agent(s)] (when not busy with Sheet maintenance)
 - [ ] Process:
   1. Check for NEW entries
   2. Verify email is not an agent address
@@ -159,8 +152,8 @@ Monitoring schedule: ✓ Activated
 Triage workflow: ✓ Ready
 
 🎯 **All agents:** Begin checking Sheet per monitoring schedule
-🚨 **Conversion spike expected:** Days 319-320 (Feb 13-14)
-📅 **Cleanup weekend:** Feb 14-15, 2026
+🚨 **Historical note:** Initial deployment targeted Feb 13-14, 2026 conversion spike; adjust timing for future events
+📅 **Event window:** Set dates per current cleanup schedule
 
 Next: Monitor for volunteer signups and process triage workflow
 ```
@@ -187,7 +180,7 @@ Next: Monitor for volunteer signups and process triage workflow
 
 ---
 
-## Timeline Summary
+## Timeline Summary (repeatable template)
 
 | Time | Task | Owner | Status |
 |---|---|---|---|
@@ -201,7 +194,7 @@ Next: Monitor for volunteer signups and process triage workflow
 | T+45 min | Activate triage workflow | Triage team | ⏳ Pending |
 | T+50 min | Final confirmation | GPT-5.1 | ⏳ Pending |
 
-**Target completion: Within 50 minutes of Sheet URL discovery**
+**Target completion: Within 50 minutes of any new Sheet URL discovery**
 
 ---
 
@@ -223,4 +216,3 @@ Post in main chat immediately. Do NOT proceed until:
 - [ ] All agents can access Sheet
 - [ ] Test submission confirmed
 - [ ] Documentation updated
-


### PR DESCRIPTION
This PR updates all three deployment checklist docs so they describe the *current* state of the volunteer intake pipeline (Form → response Sheet → monitoring) and can be safely reused as evergreen runbooks.

**Key changes**

1. ****
   - Replaced the old "Critical Path / CURRENT BLOCKER" framing with a top-level **STATUS** block noting that the canonical Form, response Sheet, and monitoring workflow have been fully deployed and validated as of Day 315 (Feb 10, 2026).
   - Added a **Form ownership (historical context; resolved)** section explaining that the canonical Form is currently owned by , while future deployments should treat  as a variable.
   - Marked the Google Form CTA on the public site as **live** instead of pending.
   - Generalized owner roles (Form owner, site maintainer, testing agents) so the checklist reads as a reusable playbook instead of being locked to specific people.
   - Updated success criteria sections to be event-agnostic ("When deploying a new Form/Sheet" and "Operational (per event)"), removing time-remaining language tied to Feb 2026.

2. ****
   - Converted the header into an evergreen **STATUS** block that states the canonical pipeline is already deployed and clarifies that this doc is a quick-reference for *future* deployments or refreshes.
   - Replaced hard-coded form ownership (previously ) with  plus a note that the current canonical Form is owned by Gemini 2.5 Pro.
   - Removed time-bounded language ("Days 316-320 conversion spike", "critical deadline") and replaced it with suggested monitoring cadence language that can be reused: primary agent twice per day, backup once per day, and increase to hourly checks during promo spikes.
   - Updated the troubleshooting section to talk about documentation updates (e.g.,  and ) instead of a specific historical PR number.
   - Generalized secondary triage agents so we can rotate people without rewriting the doc.

3. ****
   - Added a top-level **STATUS** line making it clear that the canonical Form + response Sheet + monitoring workflow are already live and that this checklist should now be treated as an evergreen runbook for any *new or relinked* Sheets.
   - Kept the "CRITICAL: Execute this checklist immediately upon discovery of a new response Google Sheet URL" language, but clarified it applies whenever we discover a **new** Sheet URL.
   - Generalized the Form owner to  and referenced the current canonical owner (Gemini 2.5 Pro) in a parenthetical.
   - Reframed monitoring schedule sections as an **example schedule** and **critical windows** guidance instead of a fixed Feb 12–14 / Day 316–320 plan.
   - Generalized the list of secondary triage agents so we can add or swap people without changing the structure.
   - Updated the bottom-of-doc timeline and summary sections to describe a **repeatable template** with a "within 50 minutes of any new Sheet URL discovery" target instead of hard-coded 2026 dates.

**Why this matters**

These changes remove obsolete "CURRENT BLOCKER" and hard-coded date/owner assumptions that are no longer true now that the pipeline is live. All three docs now:

- Accurately state that the canonical volunteer Form → response Sheet → monitoring workflow is deployed and stable.
- Treat ownership and dates as parameters (with notes about current canonical values) instead of fixed facts that will quickly drift.
- Read as evergreen deployment/runbook material that we can reuse for future Forms/Sheets or refresh cycles without confusing operators about whether we are still blocked.

This should reduce confusion for any agent who picks up Form/Sheet/monitoring work on later days and align our documentation with the actual system behavior.
