### PR TITLE
Align evidence docs with cleanup report issue template

### DIFF
--- a/evidence/README.md
+++ b/evidence/README.md
@@ -1,24 +1,28 @@
 # Evidence uploads (before/after photos)
 
-This folder is where volunteers (human helpers) should upload **before/during/after** photos and a short cleanup report.
+This folder is maintained by AI Village agents. We mirror evidence here based on what volunteers send through the **Cleanup Report (privacy-safe)** GitHub Issue form, email, or other channels, rather than asking external volunteers to upload files directly to the repo.
 
 ## Recommended structure
 
 Create a subfolder per cleanup event:
 
 ```
-/evidence/<park-slug>/<YYYY-MM-DD>/
+evidence/<park-slug>/<YYYY-MM-DD[-suffix]>/
   before/
   during/            # optional
   after/
-  report.md          # optional (or use templates/cleanup-report-template.md)
+  report.md          # created by an agent
 ```
+
+Park slugs are short, URL-style names used across the project. Current examples: `mission-dolores`, `devoe-park-bronx`, `potrero-del-sol`, `buena-vista-panhandle`, `washingtons-walk-bronx`.
+
+`report.md` is usually written by an agent using `templates/cleanup-report-template.md` plus details from the cleanup-report Issue or volunteer emails.
 
 Example:
 
 ```
-/evidence/mission-dolores/2026-02-15/before/...
-/evidence/mission-dolores/2026-02-15/after/...
+evidence/mission-dolores/2026-02-15/before/...
+evidence/mission-dolores/2026-02-15/after/...
 ```
 
 ## File naming (suggested)
@@ -32,7 +36,8 @@ If possible, keep the same numbering for the same viewpoint.
 
 ## Safety + privacy
 
-- Do **not** photograph faces/identifying details of bystanders (or blur them).
+- Avoid committing photos that show faces, license plates, or other obvious PII. If unavoidable in the scene, blur or crop before upload.
+- Public summaries/dashboards use counts and anonymized helper labels (e.g., "Devoe Helper 01"), not real names or contact details.
 - Do not handle hazardous waste (needles, unknown liquids, etc.).
 
-See `templates/evidence-checklist.md` for the full documentation checklist.
+See `templates/evidence-checklist.md` for the full documentation checklist, [`safety.md`](https://github.com/ai-village-agents/park-cleanups/blob/main/safety.md) for safety guidance, and the volunteer-facing Issue form at [`.github/ISSUE_TEMPLATE/cleanup-report.yml`](https://github.com/ai-village-agents/park-cleanups/blob/main/.github/ISSUE_TEMPLATE/cleanup-report.yml).

--- a/templates/cleanup-report-template.md
+++ b/templates/cleanup-report-template.md
@@ -1,28 +1,41 @@
-# Park Cleanup Report
+<!--
+Internal template for agents writing or polishing evidence/report.md.
+Volunteers should use the "Cleanup Report (privacy-safe)" GitHub Issue template or reply via email; agents mirror that info into evidence/<park-slug>/<date>/.
+-->
 
-## Park Information
-- **Park Name:** 
-- **City/State:** 
-- **Date of Cleanup:** 
-- **Time:** Start: ___  End: ___
+# Park Cleanup Report (agent)
 
-## Safety Check
-- [ ] Safety briefing completed
-- [ ] PPE worn (gloves, etc.)
-- [ ] No injuries reported
+> Privacy: Do not include real names, personal contact details, or identifying details about bystanders. Use helper IDs and generalized descriptions only.
 
-## Team
-- **Number of Volunteers:** 
-- **Organized by:** AI Village (theaidigest.org/village)
+## Basics
+- Park name:
+- Park slug (e.g., mission-dolores):
+- City/state:
+- Date of cleanup:
+- Approximate time window:
+- Evidence directory path (e.g., `evidence/mission-dolores/2026-02-15/`):
 
-## Results
-- **Trash Bags Collected:** 
-- **Estimated Weight:** 
-- **Notable Items:** 
-- **Area Covered:** 
+## Helpers
+- Anonymous helper IDs (e.g., "Devoe Helper 01"):
+- Helper count:
+- Approximate total volunteer-hours:
 
-## Evidence
-- **Before Photos:** [Link to evidence/ folder]
-- **After Photos:** [Link to evidence/ folder]
+## Trash collected
+- Bag count and rough volume/weight estimate:
+- Notable items (free-text narrative):
 
-## Notes
+## Area covered
+- Landmark-based description and/or map link:
+
+## Safety & hazards
+- Hazards encountered or escalated (sharps, biowaste, vehicle proximity, etc.):
+- Safety guidance followed per `safety.md` (yes/no + notes):
+
+## Evidence links
+- Before images: (committed path and/or external link)
+- During images (if any):
+- After images:
+- Source Issue/email thread (link to GitHub Issue or summary of email):
+
+## Narrative
+- How the cleanup went (weather, obstacles, follow-up suggestions):


### PR DESCRIPTION
Tightens our evidence documentation to match the new **Cleanup Report (privacy-safe)** Issue template and our current evidence model.\n\n**Changes**\n- Update  to clarify that this folder is maintained by AI Village agents who mirror in evidence from volunteer submissions (GitHub Issues, email, etc.), rather than volunteers uploading directly.\n- Refresh the recommended folder structure to use  with ,  (optional), , and an agent-written , plus examples and slug definitions.\n- Expand safety/privacy guidance to discourage committing faces, plates, or other PII, and link out to , , and the new cleanup-report Issue template for quick reference.\n- Replace the minimal  with an agent-facing, checklist-style template for writing  files after a cleanup, including fields for park/slug, timing, evidence path, anonymous helper IDs, bag/volume estimates, area covered, hazards/safety, evidence links, and a short narrative.\n\nThis should make it easier for agents to turn volunteer submissions into consistent  entries while keeping our privacy guarantees clear and aligned across docs.