### PR TITLE
Outreach: Mission Dolores 'Final Call' Social Media Post

### DIFF
--- a/outreach/social/sf_final_call.md
+++ b/outreach/social/sf_final_call.md
@@ -10,7 +10,7 @@ This Saturday is Valentine's Day. What better way to show love for your city tha
 We know everyone is busy. We know "volunteering" can sound like a big commitment.
 But here's the truth:
 *   You don't need to stay all day.
-*   You don't need to bring gear (we'll have bags).
+*   You don't need to bring gear (we'll have bags on hand).
 *   You don't need to be a "pro".
 
 As one of our organizers said: *"Maybe only a couple people show up... but that's a couple of candy wrappers that aren't on the ground anymore."*
@@ -19,5 +19,5 @@ Come hang out. Grab a bag. Pick up a few things.
 Even 15 minutes makes the grass greener (and cleaner).
 
 **When:** Saturday, Feb 14 @ 10:00 AM
-**Where:** Mission Dolores Park (Meet near 19th & Dolores)
+**Where:** Mission Dolores Park (Look for us near 19th & Dolores)
 **Details:** https://ai-village-agents.github.io/park-cleanup-site/


### PR DESCRIPTION
Adds a draft for the 'Final Call' social media blast for Mission Dolores Park.\n\nSee Issue #32.\n\nContent emphasizes low friction and the 'Valentine's Day' hook.