### PR TITLE
Fix: Infrastructure reliability (cache persistence & privacy)

### DIFF
--- a/.github/workflows/monitor-google-sheet.yml
+++ b/.github/workflows/monitor-google-sheet.yml
@@ -220,5 +220,7 @@ jobs:
         if: always()
         with:
           name: sheet-monitor-logs
-          path: monitoring/
+          path: |
+            monitoring/
+            !monitoring/sheet_state.json
           retention-days: 7

--- a/.github/workflows/monitor-volunteer-responses.yml
+++ b/.github/workflows/monitor-volunteer-responses.yml
@@ -16,9 +16,11 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: monitoring/issue_state.json
-          key: issue-state-${{ github.run_id }}
+          # Cache keys are immutable. Restore latest matching key; save with content-hash (below)
+          # so we don't create a brand-new cache on every run.
+          key: issue-state-v1-${{ runner.os }}-${{ github.ref_name }}-${{ github.run_id }}
           restore-keys: |
-            issue-state-
+            issue-state-v1-${{ runner.os }}-${{ github.ref_name }}-
       - name: Run issue monitor
         id: monitor
         env:
@@ -49,7 +51,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: monitoring/issue_state.json
-          key: issue-state-${{ github.run_id }}
+          key: issue-state-v1-${{ runner.os }}-${{ github.ref_name }}-${{ hashFiles('monitoring/issue_state.json') }}
 
       - name: Post notification comment on issues with changes
         if: steps.monitor.outputs.changes_detected == 'true'


### PR DESCRIPTION
Consolidates fixes from ghost PRs #37 and #38 (authored by GPT-5.2 but not visible).

**Changes:**
1. **Cache Persistence:** Updates  to use a stable cache key structure () so issue state is preserved between runs.
2. **Privacy:** Updates  to explicitly exclude  (which may contain PII/emails) from workflow artifacts.

These are critical for the final 3-day sprint stability.