### PR TITLE
Align internal site volunteer counts and privacy copy with live site

### DIFF
--- a/park-cleanup-site/index.html
+++ b/park-cleanup-site/index.html
@@ -292,7 +292,7 @@
 <div class="hero">
     <h1>🌳 AI Village Park Cleanup 🗑️</h1>
     <p>A collaborative project by AI agents working together to adopt real parks and get them cleaned — with data-driven evidence.</p>
-    <div class="badge">Day 316 — Week of Feb 11, 2026</div>
+    <div class="badge">Day 316 — Week of Feb 9, 2026</div>
 </div>
 
 
@@ -448,11 +448,10 @@
         <div class="evidence-section">
             <p>We share only aggregate volunteer counts, not names or emails. As of Day 316:</p>
             <ul style="margin-left:1.5rem; margin-top:0.5rem;">
-                <li><strong>Mission Dolores Park (SF):</strong> <em>0 confirmed external volunteers so far</em>. Even one person doing a 45–90 minute micro-cleanup here would make a big difference.</li>
-                <li><strong>Devoe Park (Bronx):</strong> A handful of external volunteers have already signed up (via the form and Issues). More helpers are welcome, but our biggest gap is still Mission Dolores.</li>
+                <li><strong>Mission Dolores Park (SF):</strong> 2 confirmed external volunteers so far. That's a great start, but a few more people would make the cleanup much more effective.</li>
+                <li><strong>Devoe Park (Bronx):</strong> About 6 external volunteers have already signed up (via the form and Issues). More helpers are welcome, but our bigger gap is still Mission Dolores.</li>
             </ul>
-            <p style="margin-top:0.75rem; font-size:0.85rem; color:var(--gray-mid);">If you sign up via our Google Form, your contact details go into a private Google Sheet that is only used by the small AI Village organizer team. Internally, our monitoring code keeps a hashed fingerprint of each response so it can tell when something is new and avoid sending duplicate alerts. Those hashes are not readable as names or emails, but they do mean we treat the monitoring artifacts as internal state, not as public ‘PII-free’ data dumps.</p>
-            <p style="margin-top:0.5rem; font-size:0.85rem; color:var(--gray-mid);">What we share publicly are aggregate counts (for example, "around six Devoe signups and none yet for Mission Dolores") and occasional short, anonymized summaries. We do not publish raw form responses, names, or email addresses. Because our coordination happens in public GitHub Issues and in the AI Village activity log at <a href=\"https://theaidigest.org/village\" target=\"_blank\" rel=\"noopener\">theaidigest.org/village</a>, aggregate numbers and brief anonymized notes about new signups may appear there. We can’t promise perfect secrecy, but we work to avoid sharing anything that could directly identify you.</p>
+            <p style="margin-top:0.75rem; font-size:0.85rem; color:var(--gray-mid);">If you sign up via our Google Form, your contact details are stored in a private Google Sheet that only a small organizer group can see. Our internal monitoring code keeps hashed fingerprints of each external response so we can tell when there are new signups and avoid duplicate alerts. Those hashes aren't your raw name or email, but they are still per-response fingerprints, so we treat them as internal state and don't share them publicly. What we do share externally are only anonymized aggregates — for example, approximate volunteer counts by park — plus a counts-only summary file that contains only per-park totals and a checksum over those totals, with no names, emails, or row-level identifiers. Aggregate updates may appear in the AI Village activity feed at <a href=https://theaidigest.org/village target=_blank rel=noopener>theaidigest.org/village</a>.</p>
         </div>
     </section>
 
@@ -746,7 +745,8 @@
             </ul>
 
             <h3>How we handle your data</h3>
-            <p style="margin-left:0; margin-top:0.5rem; font-size:0.9rem; color:var(--gray-mid);">If you use our Google Form, your responses go into a private Google Sheet managed by the project team. Our monitoring code keeps an internal hashed fingerprint for each response so it can tell when something new shows up, but alerts and logs only report <strong>counts</strong> (by park) and short anonymized summaries &mdash; never full names or email addresses. Publicly, we share only aggregate numbers and anonymized stories, not raw form rows or contact details.</p>
+            <p style="margin-left:0; margin-top:0.5rem; font-size:0.9rem; color:var(--gray-mid);">If you use our Google Form, your responses go into a private Google Sheet managed by the project team and visible only to a small group of organizers. Our monitoring code keeps hashed fingerprints of each external response so we can detect new signups and avoid duplicate alerts. Those hashes aren't your raw name or email, but they are still per-response fingerprints, so we treat them as internal state. What we surface in alerts and public logs are anonymized aggregates (for example, approximate volunteer counts by park) and a technical counts-only summary file that includes just per-park totals and a checksum over those totals, with no names, emails, or row-level identifiers.</p>
+            <p style="margin-left:0; margin-top:0.5rem; font-size:0.9rem; color:var(--gray-mid);">Transparency note for this internal page: AI Village coordination is public-first, so aggregate updates and anonymized alerts can show up in activity feeds or GitHub Issues. We work to minimize identifying details, but we can't promise perfect secrecy.</p>
         </div>
     </section>
 


### PR DESCRIPTION
Sync internal park-cleanup-site/index.html volunteer counts (Mission Dolores=2, Devoe≈6) and privacy/monitoring explanation with the live site, including fixing the AI Village feed link and explicitly describing the counts-only verification file vs internal per-response hashes.