### PR TITLE
fix: repair critical bugs in monitor-google-sheet.yml workflow

### DIFF
--- a/.github/workflows/monitor-google-sheet.yml
+++ b/.github/workflows/monitor-google-sheet.yml
@@ -38,7 +38,7 @@ jobs:
           # Cache keys are immutable. We restore the latest matching key and
           # save under a content-hash key (below) to avoid creating a new cache
           # on every run.
-          key: sheet-state-v1-${{ runner.os }}-${{ github.ref_name }}-${{ github.run_id }}
+          key: sheet-state-v1-${{ runner.os }}-${{ github.ref_name }}-${{ hashFiles('monitoring/sheet_state.json') }}
           restore-keys: |
             sheet-state-v1-${{ runner.os }}-${{ github.ref_name }}-
       
@@ -106,7 +106,8 @@ jobs:
               f"**Detected at:** {timestamp}",
               "",
               "**New volunteer signup(s) via Google Form:**",
-          f"- New response(s) detected: {len(details)}",
+              f"- New response(s) detected: {len(details)}",
+          ]
           
           lines.extend([
               "",
@@ -167,6 +168,7 @@ jobs:
               "",
               "**Details:**",
               f"- New response(s) detected: {len(details)}",
+          ]
           
           lines.extend([
               "",


### PR DESCRIPTION
**Issue 1: Cache-restore race condition**
The cache restore step was using github.run_id in the primary key, making each run look for a unique cache that doesn't exist. This prevented the monitoring workflow from maintaining state between runs.

Changed restore key from:
  key: sheet-state-v1-${runner.os}-${github.ref_name}-${github.run_id}
To:
  key: sheet-state-v1-${runner.os}-${github.ref_name}-${hashFiles('monitoring/sheet_state.json')}

**Issue 2: Syntax errors in embedded Python**
Two Python code blocks were missing closing brackets for the 'lines' list definition before calling lines.extend(). This would cause the workflow to fail immediately when changes are detected.

Fixed both 'Post notification to GitHub Issue' and 'Create team notification issue' steps by properly closing the initial lines list definition with ].

These fixes are critical for ensuring the monitoring workflow can properly:
- Maintain state between runs to detect new volunteer signups
- Execute without syntax errors when processing those signups

Essential for robust volunteer alert functionality during Feb 13-14 conversion spike.