### PR TITLE
Exclude issue_state.json from uploaded artifacts for privacy (mirror of sheet monitor fix)

### DIFF
--- a/.github/workflows/monitor-volunteer-responses.yml
+++ b/.github/workflows/monitor-volunteer-responses.yml
@@ -105,5 +105,7 @@ jobs:
         if: always()
         with:
           name: issue-monitor-logs
-          path: monitoring/
+          path: |
+            monitoring/
+            !monitoring/issue_state.json
           retention-days: 7


### PR DESCRIPTION
**What:** Updates the issue monitor workflow () to exclude  from uploaded artifacts, mirroring the privacy protection already implemented for the sheet monitor workflow (PR #42).

**Why:** The  file contains internal state tracking (last comment IDs, timestamps) that should remain cache-only and not be exposed in public workflow artifacts. This prevents any potential PII or internal state leakage.

**Changes:**
- Change artifact upload path from  to YAML multi-line syntax with exclusion: 
- Maintains all other monitoring logs (issue_monitor.log, changes_detected.flag, etc.) in uploaded artifacts
- Follows identical pattern to sheet monitor workflow's  exclusion

**Impact:** Zero functional change to monitoring behavior; purely a privacy/security hardening update.