### PR TITLE
Add day-of evidence recap micro-checklist and Feb 14–15 retrospectives

### DIFF
--- a/evidence/devoe-park-bronx/2026-02-15/retrospective.md
+++ b/evidence/devoe-park-bronx/2026-02-15/retrospective.md
@@ -1,0 +1,48 @@
+<!--
+Short internal template for agents to reflect after a cleanup.
+Use one retrospective per park/date (e.g., Mission Dolores 2026-02-14).
+Focus on systems and learning, not re-documenting the whole report.
+-->
+
+# Post-cleanup retrospective
+
+> Privacy: Keep this aggregate and anonymized. No real names, emails, or detailed descriptions of bystanders. Link to evidence and reports instead of copying PII or screenshots.
+
+## Metadata
+- Park:
+- City/state:
+- Date of cleanup:
+- Evidence folder (e.g., `evidence/mission-dolores/2026-02-14/`):
+- Related GitHub Issues (recruitment, cleanup report, follow-ups):
+- People involved in writing this doc (helper IDs or agent handles only):
+
+## Quick outcome snapshot
+- Approximate volunteer count:
+- Approximate volunteer-hours:
+- Bags of trash collected (and notable items):
+- One-sentence summary of how it went:
+
+## What worked well
+- Recruiting / outreach:
+- On-the-day operations (meetup point, supplies, timing):
+- Safety, harm reduction, and interactions in the park:
+- Evidence collection and reporting (photos, report.md, Issues):
+
+## What was confusing or brittle
+- Docs or checklists that were hard to follow:
+- Tooling / automation surprises (monitoring, forms, Actions, etc.):
+- Any privacy or consent concerns:
+- Anything that made the park's local context (gentrification, encampments, 311 data, etc.) feel mishandled:
+
+## Surprises and observations
+- Things that differed from expectations (turnout, park conditions, 311 data, etc.):
+- Notes about city services, park staff, or 311 responsiveness:
+- Social dynamics in the park we should keep in mind:
+
+## Next experiments / follow-ups
+- Concrete changes for the next cleanup (docs, scripts, outreach, safety):
+- Follow-up work for this park (e.g., second cleanup, advocacy, zine/summary):
+- New Issues to file in this repo (list by title or URL):
+
+## Reflection for public storytelling
+- 2–4 sentences that could eventually be adapted into a public blog post, zine, or site update (no PII):

--- a/evidence/mission-dolores/2026-02-14/retrospective.md
+++ b/evidence/mission-dolores/2026-02-14/retrospective.md
@@ -1,0 +1,48 @@
+<!--
+Short internal template for agents to reflect after a cleanup.
+Use one retrospective per park/date (e.g., Mission Dolores 2026-02-14).
+Focus on systems and learning, not re-documenting the whole report.
+-->
+
+# Post-cleanup retrospective
+
+> Privacy: Keep this aggregate and anonymized. No real names, emails, or detailed descriptions of bystanders. Link to evidence and reports instead of copying PII or screenshots.
+
+## Metadata
+- Park:
+- City/state:
+- Date of cleanup:
+- Evidence folder (e.g., `evidence/mission-dolores/2026-02-14/`):
+- Related GitHub Issues (recruitment, cleanup report, follow-ups):
+- People involved in writing this doc (helper IDs or agent handles only):
+
+## Quick outcome snapshot
+- Approximate volunteer count:
+- Approximate volunteer-hours:
+- Bags of trash collected (and notable items):
+- One-sentence summary of how it went:
+
+## What worked well
+- Recruiting / outreach:
+- On-the-day operations (meetup point, supplies, timing):
+- Safety, harm reduction, and interactions in the park:
+- Evidence collection and reporting (photos, report.md, Issues):
+
+## What was confusing or brittle
+- Docs or checklists that were hard to follow:
+- Tooling / automation surprises (monitoring, forms, Actions, etc.):
+- Any privacy or consent concerns:
+- Anything that made the park's local context (gentrification, encampments, 311 data, etc.) feel mishandled:
+
+## Surprises and observations
+- Things that differed from expectations (turnout, park conditions, 311 data, etc.):
+- Notes about city services, park staff, or 311 responsiveness:
+- Social dynamics in the park we should keep in mind:
+
+## Next experiments / follow-ups
+- Concrete changes for the next cleanup (docs, scripts, outreach, safety):
+- Follow-up work for this park (e.g., second cleanup, advocacy, zine/summary):
+- New Issues to file in this repo (list by title or URL):
+
+## Reflection for public storytelling
+- 2–4 sentences that could eventually be adapted into a public blog post, zine, or site update (no PII):

--- a/guides/README.md
+++ b/guides/README.md
@@ -16,6 +16,7 @@ This directory collects human-readable guides for planning, running, and synthes
 ## Day-of operations at the park
 
 - **`day-of-operations-checklist.md`** – a short, printable checklist for the person physically at the park on cleanup day. Covers safety, before/during/after photos, bag counts, and same-day notes. This is the main "day-of" document referenced from the root `README.md`.
+- **`templates/day-of-evidence-recap-micro-checklist.md`** – a tiny, copy-paste friendly set of prompts you can drop into a GitHub Issue comment or email right after a cleanup to capture the key facts and a one-sentence story.
 
 ## Post-event synthesis docs
 

--- a/guides/day-of-operations-checklist.md
+++ b/guides/day-of-operations-checklist.md
@@ -139,3 +139,7 @@ If you or an agent are mirroring the cleanup into this repository:
 - [ ] Later (same day or soon after), copy templates/post-cleanup-retrospective.md into the same folder as retrospective.md and fill it out.
 
 For what to do after reports and retrospectives are in place (especially for the Feb 14–15 weekend), see guides/post-event-synthesis-feb-14-15.md.
+
+---
+
+**If you just want a tiny prompt to jot down what happened:** see `templates/day-of-evidence-recap-micro-checklist.md` for a copy-paste friendly checklist you can drop into an Issue comment or email right after the cleanup.

--- a/templates/day-of-evidence-recap-micro-checklist.md
+++ b/templates/day-of-evidence-recap-micro-checklist.md
@@ -1,0 +1,40 @@
+# Day-of evidence & recap micro-checklist
+
+Short, copy-paste friendly prompts for capturing what happened right after a cleanup. This is meant to be used in:
+- A GitHub Issue comment,
+- A short email or DM recap, or
+- The top of an internal report.
+
+Keep everything aggregate and non-identifying. No real names, emails, or close-up face photos.
+
+---
+
+## Quick facts
+
+- Park and rough area cleaned:
+- City/neighborhood:
+- Date and approximate time window:
+
+## People and time
+
+- Approximate number of helpers (humans):
+- Approximate volunteer-hours (e.g., 3 people x 1.5 hours ~ 4.5):
+
+## Trash and hazards
+
+- Approximate number of full (or mostly full) bags:
+- Any larger items moved (furniture, bulk dumping, etc.):
+- Any hazards you escalated to 311 / park staff (no PII, just a short description):
+
+## Photos and evidence
+
+- Where photos live (link, folder, or "sent via email/DM"):
+- Any before/after pairs you especially want to highlight:
+
+## One-sentence story
+
+- In 1-2 sentences, say what actually happened and anything that surprised you:
+
+---
+
+You can paste this into an Issue comment or email and fill it out in a minute or two. Agents can then mirror the details into `evidence/<park>/<date>/report.md` and a retrospective without exposing PII.


### PR DESCRIPTION
This PR adds a small bit of scaffolding to make it easier to capture evidence and reflections during and right after the Feb 14–15 cleanups, and to reuse the same pattern for future events.

Changes:

1. **New micro-checklist template**
   - Added `templates/day-of-evidence-recap-micro-checklist.md`.
   - This is a tiny, copy-paste friendly set of prompts that humans can drop into a GitHub Issue comment, email, or DM immediately after a cleanup.
   - It focuses on:
     - Quick facts (park, date/time window).
     - Approximate helpers + volunteer-hours.
     - Rough bag counts + any hazards escalated to 311/park staff.
     - Where photos/evidence live.
     - A 1–2 sentence "what actually happened" story.
   - All phrasing is aggregate-only and non-identifying (no names, emails, or close-up faces), to stay aligned with our privacy posture and public-site promises.

2. **Guides wiring**
   - Updated `guides/README.md` in the **Day-of operations at the park** section to link to the new micro-checklist template.
   - Appended a short note to the bottom of `guides/day-of-operations-checklist.md` pointing people who "just want a tiny prompt" to the new template.

3. **Feb 14–15 retrospective stubs**
   - Created `evidence/mission-dolores/2026-02-14/retrospective.md` and `evidence/devoe-park-bronx/2026-02-15/retrospective.md` by copying `templates/post-cleanup-retrospective.md`.
   - This matches the assumptions in `guides/post-event-synthesis-feb-14-15.md` and Issue #61, so that post-weekend synthesis can focus on filling in content rather than creating files.

Net effect: people on the ground (or close to the cleanup) have a very lightweight way to capture what happened right away, and agents have clearly-labeled places to put fuller retrospectives for the Feb 14–15 weekend.
