### PR TITLE
Chore: harmonize sharps safety guidance and Mission Dolores meetup address

### DIFF
--- a/guides/day-of-operations-checklist.md
+++ b/guides/day-of-operations-checklist.md
@@ -22,7 +22,7 @@ It assumes:
   - [ ] Trash bags (contractor or heavy-duty if possible)
   - [ ] Trash grabbers or tongs
   - [ ] Hand sanitizer or wipes
-  - [ ] Optional: sharps container or thick plastic bottle with lid (if you have one and know how to use it safely)
+  - [ ] Optional: official sharps container (only if you are part of a formal sharps-handling program; otherwise, do not plan to handle needles—treat them as hazards to report to 311 or park staff).
 
 - [ ] **Docs to glance at once** (no need to memorize)
   - [ ] safety.md
@@ -40,7 +40,7 @@ It assumes:
 - [ ] **Quick safety huddle (5 minutes)** with anyone helping
   - [ ] PPE on (gloves at minimum).
   - [ ] Eyes before hands rule — look carefully before reaching anywhere you can’t clearly see.
-  - [ ] Do not handle needles, broken glass, or other sharp/medical waste unless you are trained and equipped.
+  - [ ] Do not handle needles, broken glass, or other sharp/medical waste. For this project, the default is to treat sharps as hazards to report to 311 or park staff, not something to pick up — unless you are there as part of a formal sharps-handling program with proper containers.
   - [ ] Respect all park users, including unhoused neighbors and vendors.
   - [ ] Do not disturb tents or personal belongings. Use 311 or park staff for hazards.
   - [ ] Keep bags small enough to lift safely; don’t overload.

--- a/safety.md
+++ b/safety.md
@@ -8,9 +8,9 @@
 
 ## Handling Trash & Debris
 - Follow the **“Eyes Before Hands”** rule: look carefully before reaching.
-- **Sharps & Needles:** Do not touch with bare or gloved hands. Use grabbers or tongs. If no sharps container is available, use a thick plastic bottle with a screw cap, label it, and hand it to site lead.  
-  - SF: If an item looks unsafe to move, call 311 for pickup.  
-  - NYC: Report “Syringe Litter” to 311.
+- **Sharps & Needles:** For this project, do not handle needles, syringes, or other sharps — even with gloves, grabbers, or bottles. Treat them as hazards to be reported, not trash to be picked up. If you are part of a formal, city-run sharps program with proper containers, follow that program’s instructions; everyone else should not attempt to move sharps.  
+  - SF: If you see a needle or similar sharp item, note the location and call 311 or use the SF 311 app for pickup.  
+  - NYC: Use the NYC 311 app or call 311 to report “Syringe Litter.”
 - Unknown liquids: Do not touch or open containers.
 - Lifting: Bend at knees and hips, keep load close, and get help for heavy or awkward items.
 

--- a/templates/volunteer-welcome-email.md
+++ b/templates/volunteer-welcome-email.md
@@ -34,7 +34,7 @@ Thank you for signing up for our park cleanup project! We're thrilled to have yo
 
 - Comfortable, weather-appropriate clothing (layering recommended)
 - Closed-toe shoes
-- Gloves (we can provide if needed)
+- Work or gardening gloves (we may have a few on hand, but please bring your own if you can)
 - Reusable bag or backpack
 - Water bottle
 - Sunscreen & hat (if sunny)
@@ -49,7 +49,7 @@ Thank you for signing up for our park cleanup project! We're thrilled to have yo
 ## During the Cleanup
 
 Our team will:
-- Provide supplies and organize work areas
+- Help coordinate simple work areas with whatever supplies we have (please still bring your own gloves/bag if you can)
 - Welcome you when you arrive
 - Guide you through different cleanup tasks (bagging litter, organizing supplies, etc.)
 - Take group photos for documentation
@@ -98,7 +98,7 @@ Replace the following placeholders with actual event info:
 |---|---|---|
 | `[VOLUNTEER_NAME]` | From Form: Name field | "Sarah" or "Marcus" |
 | `[PARK_NAME]` | From Form: Park choice field | "Mission Dolores Park" or "Devoe Park" |
-| `[FULL_ADDRESS]` | Devoe: "W 188th St & University Ave, Bronx, NY 10468"<br>Mission Dolores: "Dolores St at 18th St, San Francisco, CA 94103" | (See park details below) |
+| `[FULL_ADDRESS]` | Devoe: "W 188th St & University Ave, Bronx, NY 10468"<br>Mission Dolores: "Dolores St & 19th St, San Francisco, CA 94114" | (See park details below) |
 | `[DATE]` | Devoe: "Sunday, February 15, 2026"<br>Mission Dolores: "Saturday, February 14, 2026" | "Sunday, February 15, 2026" |
 | `[TIME_RANGE]` | Typically 9am-12pm or 10am-1pm; ask volunteer preference | "9:00 AM - 12:00 PM" |
 | `[TRANSIT_DIRECTIONS]` | Look up directions from major transit hub | See park details below |
@@ -113,7 +113,7 @@ Replace the following placeholders with actual event info:
 
 ### Mission Dolores Park, San Francisco (Feb 14, 2026)
 
-**Address:** Dolores St at 18th St, San Francisco, CA 94103
+**Address:** Dolores St & 19th St, San Francisco, CA 94114
 
 **Transit:**
 - BART: 24th St Mission Station (10 min walk)
@@ -167,7 +167,7 @@ When drafting the email:
 - Use exclamation marks sparingly but genuinely
 - Emphasize community and impact
 - Make the logistics clear and easy to follow
-- Offer flexibility ("no experience necessary," "we can provide gloves")
+- Offer flexibility ("no experience necessary," "we may have some gloves, but please bring your own if you can")
 - Follow up on their specific request (e.g., if they said morning preference, confirm morning)
 
 ❌ **Don't:**
@@ -192,7 +192,7 @@ Thank you for signing up for our park cleanup project! We're thrilled to have yo
 ## Event Details
 
 **Park:** Mission Dolores Park
-**Location:** Dolores St at 18th St, San Francisco, CA 94103
+**Location:** Dolores St & 19th St, San Francisco, CA 94114
 **Date:** Saturday, February 14, 2026
 **Time:** 9:00 AM - 12:00 PM (please arrive 10 minutes early)
 **Duration:** Approximately 2-3 hours
@@ -206,7 +206,7 @@ Thank you for signing up for our park cleanup project! We're thrilled to have yo
 
 - Comfortable, weather-appropriate clothing (light jacket & layers recommended)
 - Closed-toe shoes
-- Gloves (we can provide if needed)
+- Work or gardening gloves (we may have a few on hand, but please bring your own if you can)
 - Reusable bag or backpack
 - Water bottle
 - Sunscreen & hat


### PR DESCRIPTION
This PR does a small but important round of harmonization so our written guidance matches what we actually want volunteers to do, and so our Mission Dolores meetup address is consistent everywhere we expose it.

**1. Sharps / needles / medical waste: single conservative policy**

We had slightly divergent guidance across docs about whether and how volunteers should pick up needles or other sharps (including an improvised "thick plastic bottle as sharps container" idea in ). This PR standardizes on a single, conservative policy:

- Ordinary volunteers do **not** pick up needles, syringes, sharps, or obvious medical/biological waste.
- They should treat sharps as hazards to **note and report**, not as trash to bag.
- The only exception is if someone is explicitly present *as part of a formal sharps-handling program* with a proper sharps container and training, in which case they follow that program’s rules.

Concretely:
- ****
  - Removes improvised sharps container advice (no more "grabbers + thick plastic bottle with a lid").
  - Reframes sharps guidance to: do not pick them up; instead, note approximate location and escalate through the relevant city channel or park staff.
  - Mentions example escalation paths for SF (311) and NYC (311 "syringe litter" / park staff), while keeping it clear this is not a police-first or carceral framing.

- ****
  - Aligns the day-of safety huddle with the above: volunteers are told explicitly not to handle needles/sharps or medical waste, and to stop and escalate instead.
  - Makes it clear that bringing a sharps container would only make sense for someone who is already part of a formal sharps program.

This brings the general safety doc and the practical day-of script into agreement, and leans toward a safer / more harm-reduction-oriented default.

**2. Mission Dolores meetup address: consistent, specific canonical form**

We had a lingering inconsistency around the Mission Dolores meetup address in our volunteer welcome email template (some text still referenced "Dolores St at 18th St"). For clarity and wayfinding, this PR standardizes on:

> **Dolores St & 19th St, San Francisco, CA 94114**

Concretely:
- ****
  - Updates the Mission Dolores address in the customization table and in the fully worked example email so they both use the exact same canonical address string above.
  - Keeps other nearby references (e.g., mentioning the 18th/Church area) only where they’re genuinely helpful context and not the primary meetup pin.

**3. Supply expectations: realistic gloves / bags language**

While touching the welcome email template, this PR also tightens up how we talk about supplies so we don’t over-promise what organizers can reliably bring:

- We now say we **may** have some gloves or bags, but **ask volunteers to bring their own if they can**.
- This gets reflected in both the generic "what to bring" guidance and the Mission Dolores worked example text.

---

This is intentionally a small, low-risk cleanup:
- No code or workflow behavior changes.
- All edits are Markdown text and should be easy to skim-review.

Reviewers: sanity-check that the sharps guidance now reads consistently conservative ("note and report, don’t pick up" unless you’re formal sharps staff), and that the Mission Dolores address now consistently appears as "Dolores St & 19th St, San Francisco, CA 94114" everywhere in the welcome email template where a meetup pin or full address is implied.
