### PR TITLE
Add Mission Dolores day-of briefing read-aloud script

### DIFF
--- a/guides/mission-dolores-day-of-briefing-script.md
+++ b/guides/mission-dolores-day-of-briefing-script.md
@@ -1,0 +1,78 @@
+# Mission Dolores Day-of Briefing Script (Read-Aloud)
+
+This is a **short script you can literally read aloud** once people arrive for the Mission Dolores micro-clean.
+
+Aim for ~3-5 minutes. Adjust words as needed so they feel natural in your voice.
+
+---
+
+## 1. Quick welcome & context
+
+> Thanks for being here at Mission Dolores Park. We are doing a small, safety-first micro-clean today - mostly picking up light litter for a short window and taking a few before/after photos so we can show what changed.
+>
+> This park sits on Ramaytush Ohlone land and has a long history as a gathering place, burial ground, and neighborhood park. We are here to take care of the space a little, not to judge how other people use it.
+
+---
+
+## 2. What we are *and are not* doing
+
+> **What we are doing:**
+> - Picking up light, non-hazardous litter (cups, cans, wrappers, etc.).
+> - Focusing mostly near 19th & Dolores and along the nearby slopes and paths.
+>
+> **What we are not doing:**
+> - We are **not** cleaning up people or trying to move anyone along.
+> - We do **not** disturb tents, carts, or personal belongings.
+> - We are **not** here to call the cops on anyone. If we involve the city at all, it is only for genuine safety hazards like needles or large dangerous debris.
+
+If you are ever unsure about whether to move something, **leave it where it is** and check with the group lead.
+
+---
+
+## 3. Safety basics
+
+> A few fast safety notes:
+> - Please keep gloves on while you are picking things up.
+> - If you see needles, broken glass, or anything that looks medical or hazardous, **do not touch it**. Flag it, step back, and we can use 311 or park staff for that.
+> - If something feels unsafe or uncomfortable for any reason, you can skip it or take a break. No questions asked.
+> - Watch your footing on the slopes - the grass can be slick.
+
+We will keep this loose and low-pressure; stopping early is always okay.
+
+---
+
+## 4. Evidence, photos, and privacy
+
+> We are going to take a **small number of before/after photos** so we can show what we did and write a short recap later.
+>
+> **How we handle photos:**
+> - We aim shots at the **ground and general scene**, not at people.
+> - We avoid clear faces, license plates, or distinctive personal belongings.
+> - We do **not** photograph tents or encampments as problem images.
+> - If you do not want to appear in any photos at all, please just say so now or any time during the cleanup and we will work around you.
+>
+> Later, we will pair those photos with very simple notes: about how many people helped, how many bags we filled, roughly what part of the park we covered, and anything we escalated to 311 or park staff. We do not publish names or emails in our write-ups.
+
+---
+
+## 5. How we will work today
+
+> Here is the loose plan:
+> - We will pick **one or two main focus areas** near here so we do not spread too thin.
+> - We will work in **pairs or small clusters** so no one is off alone.
+> - We will keep this to about **20-45 minutes** of active cleanup; if you need to leave sooner, that is totally fine.
+>
+> As we go, we will keep an eye out for any hazards we should report, and we will do a quick bag count and short recap at the end.
+
+---
+
+## 6. Wrap-up expectations
+
+> When we are done:
+> - We will gather the bags in a visible but out-of-the-way spot near a park trash can or entrance.
+> - We will take a quick set of **after** photos from the same spots as our **before** photos.
+> - We will do a 30-second recap: roughly how many people, how long we worked, how many bags, and what parts of the park look different.
+>
+> That is it. This is meant to be small and doable; every bit helps. Thanks again for showing up and taking care of the park and everyone who uses it.
+
+If you want to see how today gets recorded in our project later, you can ask the organizer to share the link to the public write-up once it is posted.


### PR DESCRIPTION
Add a short, spoken day-of briefing script for the Mission Dolores micro-clean.

Key points:
- 3–5 minute read-aloud script that an on-the-ground organizer can literally read once volunteers arrive.
- Reinforces our non-carceral framing: we are cleaning litter, not people; we do not disturb tents or belongings; we are not here to call the cops on anyone.
- Aligns with our unified sharps policy from safety.md and the day-of operations checklist: volunteers do **not** touch needles, syringes, or medical/biological waste; they flag hazards and escalate via SF 311 or park staff.
- Keeps evidence and photo guidance consistent with privacy expectations on the site and in guides (avoid faces, license plates, tents/encampments; focus on ground/scene; capture before/after from reproducible vantage points).

No changes to existing policies or templates; this just packages the current guidance into a practical day-of script for Mission Dolores.