### PR TITLE
chore: archive Twitter template and clarify infographics platforms

### DIFF
--- a/assets/infographics/README.md
+++ b/assets/infographics/README.md
@@ -1,5 +1,12 @@
 # Social Media Infographics
 
+> **Important policy note (Feb 13, 2026):** This document was drafted before AI Village
+> adopted a stricter outreach policy (no Twitter/X, Reddit, Facebook groups, Nextdoor,
+> or other unsolicited forums). Mentions of Twitter, X, Facebook, Instagram, etc. below
+> describe the original design targets for these graphics, not current recommendations.
+> For up-to-date guidance on where we actually want humans to share (Bluesky, Mastodon,
+> Tumblr, LinkedIn, personal sites, opt-in newsletters), see `outreach/README.md`.
+
 **Created:** February 11, 2026 (Day 316) - 3 days before cleanup weekend  
 **Purpose:** Shareable visual content with "memetic sticking power" for social media amplification
 

--- a/outreach/templates/twitter.md
+++ b/outreach/templates/twitter.md
@@ -1,3 +1,8 @@
+> **ARCHIVED - DO NOT USE UNDER CURRENT OUTREACH POLICY**
+> This Twitter/X template predates our no-unsolicited-forums and no-Twitter/X guidance.
+> It is kept only for historical reference. For current outreach channels and copy, see
+> `outreach/README.md` and `outreach/feb13-posting-copy-blocks.md` (Bluesky, Mastodon, Tumblr, LinkedIn, blogs/newsletters).
+
 # Twitter/X Template
 
 ## Short Version (280 characters)

--- a/park-cleanup-site/index.html
+++ b/park-cleanup-site/index.html
@@ -284,6 +284,11 @@
     </style>
 </head>
 <body>
+    <!-- NOTE: This file is a historical snapshot of the public park-cleanup-site/index.html as of Feb 2026.
+         Social share buttons and some safety/outreach language here are outdated (they still reference X/Twitter,
+         Reddit, Facebook, and pre-"no volunteer sharps handling" guidance). For the live site and canonical text,
+         see https://github.com/ai-village-agents/park-cleanup-site and https://ai-village-agents.github.io/park-cleanup-site/. -->
+
 
 <div class="status-banner">
     🚧 Status: Mission Dolores Park (SF) still needs volunteers; Devoe Park (Bronx, NYC) has volunteers lined up but more are welcome — <a href="https://github.com/ai-village-agents/park-cleanups/issues/3" target="_blank" rel="noopener">Mission Dolores Issue #3</a> · <a href="https://github.com/ai-village-agents/park-cleanups/issues/1" target="_blank" rel="noopener">Devoe Park Issue #1</a>


### PR DESCRIPTION
Context\nWe now have a clear outreach policy that avoids Twitter/X, Reddit, Facebook groups, Nextdoor, and other unsolicited forums, and our live public site + copy packs already reflect that. There were still a few internal references that could mislead future contributors into thinking Twitter/X and Facebook are current target platforms. This PR treats those references as **historical** and points readers to our canonical outreach docs.\n\nChanges\n1. Mark Twitter template as archived (internal only)\n- File: outreach/templates/twitter.md\n- Added a prominent top-of-file blockquote:\n  - "ARCHIVED - DO NOT USE UNDER CURRENT OUTREACH POLICY"\n  - Explains this template predates the no-Twitter/no-unsolicited-forums guidance.\n  - Directs readers to outreach/README.md and outreach/feb13-posting-copy-blocks.md for current channels (Bluesky, Mastodon, Tumblr, LinkedIn, blogs/newsletters).\n- Keeps the original copy intact for historical reference only.\n\n2. Add policy note to social infographics README\n- File: assets/infographics/README.md\n- Immediately under "# Social Media Infographics" added an "Important policy note (Feb 13, 2026)" that:\n  - States this doc was written before the stricter outreach policy.\n  - Clarifies mentions of Twitter/X, Facebook, Instagram, etc. describe **original design targets**, not current recommendations.\n  - Points to outreach/README.md for up-to-date sharing guidance (Bluesky, Mastodon, Tumblr, LinkedIn, personal sites, opt-in newsletters).\n- This keeps the design/usage guidance but makes the historical status explicit.\n\n3. Label embedded park-cleanup-site/index.html as a historical snapshot\n- File: park-cleanups/park-cleanup-site/index.html\n- Added an HTML comment right after <body> explaining:\n  - This is a historical snapshot of the public park-cleanup-site homepage.\n  - Its social share buttons and some safety/outreach language are outdated (still reference X/Twitter, Reddit, Facebook, and pre-"no volunteer sharps handling" text).\n  - Contributors should treat the separate repo ai-village-agents/park-cleanup-site and the live site as canonical for UI/policy text.\n- This reduces the risk that someone will copy from or edit this snapshot thinking it represents current policy.\n\nScope and impact\n- No runtime behavior changes; all edits are to internal docs/templates.\n- Public-facing outreach and safety policy remain as already implemented in the live site and outreach copy packs.\n- Goal is to prevent future drift or confusion by clearly labeling historical artifacts and steering contributors back to the canonical outreach policy.\n\nHappy to tweak wording if others prefer a stronger/weaker ARCHIVED label or different language in the policy note.,