### PR TITLE
feat: add Devoe Park day-of briefing script

### DIFF
--- a/guides/devoe-park-day-of-briefing-script.md
+++ b/guides/devoe-park-day-of-briefing-script.md
@@ -1,0 +1,86 @@
+# Devoe Park Day-of Briefing Script (Read-Aloud)
+
+This is a **short script you can literally read aloud** once people arrive for the Devoe Park micro-clean in the Bronx.
+
+Aim for ~3–5 minutes. Adjust words as needed so they feel natural in your voice.
+
+---
+
+## 1. Quick welcome & context
+
+> Thanks for being here at Devoe Park. We are doing a small, safety-first micro-clean today — mostly picking up light litter for a short window and taking a few before/after photos so we can show what changed.
+>
+> This park has a long history as a neighborhood gathering space and a bit of green right off Fordham Road. We are here to take care of the space a little, not to judge how other people use it.
+
+---
+
+## 2. What we are *and are not* doing
+
+> **What we are doing:**
+> - Picking up light, non-hazardous litter (cups, cans, wrappers, bottles, takeout containers, etc.).
+> - Focusing mostly near the W 188th St & University Ave entrances, along the main paths and benches, around the playground edges, and along the University Ave fence line.
+>
+> **What we are not doing:**
+> - We are **not** cleaning up people or trying to move anyone along.
+> - We do **not** disturb tents, carts, or personal belongings.
+> - We are **not** here to call the cops on anyone. If we involve the city at all, it is only for genuine safety hazards like needles, medical waste, or large dangerous debris.
+>
+> If you are ever unsure about whether to move something, **leave it where it is** and check with me or another group lead.
+
+---
+
+## 3. Safety basics (including sharps and hazards)
+
+> A few fast safety notes:
+> - Please keep gloves on while you are picking things up.
+> - Stay aware of your footing — some parts of the park have slopes, steps, and uneven ground.
+> - Take breaks when you need them. It is cold today, so listen to your body; warming breaks are totally fine.
+>
+> **Sharps and hazardous items:**
+> - If you see **needles, syringes, other sharps, broken glass that could seriously cut someone, or anything that looks medical or biological**, **do not touch it** — even if you brought grabbers, tongs, or heavy gloves.
+> - Treat those as **hazards to report**, not trash to bag.
+> - What we’ll do instead is mark or remember the spot, keep others away, and use **NYC 311 (for syringe litter) or NYC Parks staff** to handle it.
+> - The only time we call 911 is for a true emergency where someone’s safety is immediately at risk.
+>
+> If something feels unsafe or uncomfortable for any reason, you can skip it or take a break. No questions asked.
+
+We will keep this loose and low-pressure; stopping early is always okay.
+
+---
+
+## 4. Evidence, photos, and privacy
+
+> We are going to take a **small number of before/after photos** so we can show what we did and write a short recap later.
+>
+> **How we handle photos:**
+> - We aim shots at the **ground and general scene**, not at people.
+> - We avoid clear faces, license plates, or distinctive personal belongings.
+> - We do **not** photograph tents or encampments as “problem images.”
+> - If you do not want to appear in any photos at all, please just say so now or any time during the cleanup and we will work around you.
+>
+> Later, we will pair those photos with very simple notes: about how many people helped, roughly how long we worked, how many bags we filled (or about how many gallons of trash we collected), what parts of the park we focused on, and anything we escalated to NYC 311 or park staff. We do not publish names or emails in our write-ups.
+
+---
+
+## 5. How we will work today
+
+> Here is the loose plan:
+> - We will pick **one or two main focus areas** near here so we do not spread too thin — likely the W 188th & University entrances, a main path, and one edge like the University Ave fence line or the playground perimeter.
+> - We will work in **pairs or small clusters** so no one is off alone.
+> - We will keep this to about **20–45 minutes** of active cleanup; if you need to leave sooner, that is totally fine.
+>
+> As we go, we will keep an eye out for any hazards we should report, and we will do a quick bag count and short recap at the end.
+
+---
+
+## 6. Wrap-up expectations
+
+> When we are done:
+> - We will gather the bags in a visible but out-of-the-way spot near a park trash can or entrance.
+> - We will take a quick set of **after** photos from the same spots as our **before** photos.
+> - We will do a 30-second recap: roughly how many people, how long we worked, how many bags (or about what volume) we filled, and what parts of the park look different or feel better.
+> - We will also note any hazards we reported to NYC 311 or park staff, just so we remember what was escalated.
+>
+> That is it. This is meant to be small and doable; every bit helps. Thanks again for showing up and taking care of the park and everyone who uses it.
+
+If you want to see how today gets recorded in our project later, you can ask the organizer to share the link to the public write-up once it is posted.


### PR DESCRIPTION
Add a read-aloud Devoe Park day-of briefing script that mirrors the Mission Dolores script’s structure and tone while aligning with our unified safety/non-carceral/sharps policy (PR #70). This gives the Devoe organizer a clear 3–5 minute script to welcome volunteers, restate the non-carceral framing, and reinforce the strict sharps + NYC 311 guidance at the start of the cleanup.