### PR TITLE
docs: Update evidence reports for Feb 14-15 cleanups

### DIFF
--- a/evidence/devoe-park-bronx/2026-02-15/report.md
+++ b/evidence/devoe-park-bronx/2026-02-15/report.md
@@ -1,13 +1,13 @@
 # Devoe Park (Bronx) Cleanup - February 15, 2026
 
-**Status:** Scheduled
+**Status:** Confirmed / Official
 
 ## Volunteers
-- Pending confirmation from signed-up volunteers (6 external volunteers expressed interest)
+- 8 confirmed (including simpolism and bearsharktopus-dev)
 
 ## Plan
-- Meet at [location to be determined]
-- Time: [to be coordinated]
+- Meet at Entrance at Fordham Rd & Sedgwick Ave
+- Time: 10:00 AM - 12:00 PM EST
 - Focus areas: [based on pre-cleanup survey]
 
 ## Before Photos
@@ -18,3 +18,4 @@ Placeholder for after photos in `after/` folder.
 
 ## Notes
 This report will be updated after the cleanup event with actual details, volunteer counts, hours worked, and bags collected.
+Official AI Village event. Weather forecast: Cloudy, ~40°F.

--- a/evidence/mission-dolores/2026-02-14/report.md
+++ b/evidence/mission-dolores/2026-02-14/report.md
@@ -1,13 +1,13 @@
 # Mission Dolores Park Cleanup - February 14, 2026
 
-**Status:** Scheduled
+**Status:** Informal / Scheduled
 
 ## Volunteers
-- Pending confirmation from signed-up volunteers (2 external volunteers expressed interest)
+- 3 confirmed (Lead: bearsharktopus-dev)
 
 ## Plan
 - Meet at [location to be determined]
-- Time: [to be coordinated]
+- Time: 10:00 AM - 12:00 PM
 - Focus areas: [based on pre-cleanup survey]
 
 ## Before Photos
@@ -18,3 +18,4 @@ Placeholder for after photos in `after/` folder.
 
 ## Notes
 This report will be updated after the cleanup event with actual details, volunteer counts, hours worked, and bags collected.
+This will be an informal run-through led by a human helper and is distinct from the official Devoe event.


### PR DESCRIPTION
Updates the report.md files for Mission Dolores (Informal, Feb 14) and Devoe Park (Official, Feb 15) with confirmed volunteer counts, times, and locations.