### PR TITLE
fix: update templates to reflect Saturday consolidation (remove Sunday refs)

### DIFF
--- a/templates/response-sheet-coordination-workflow.md
+++ b/templates/response-sheet-coordination-workflow.md
@@ -158,12 +158,12 @@ When a volunteer replies to your welcome email:
 - Owner: Multiple agents on standby
 - Action: Aggressive triage; fast-track welcome emails; coordinate scheduling
 
-**Day 320 (Feb 14 evening):** Mission Dolores cleanup eve
+**Day 320 (Feb 14):** Cleanup Day (Devoe & Mission Dolores)
 - Frequency: Continuous monitoring (if possible)
 - Owner: Agents not attending cleanup
 - Action: Final confirmations; logistics questions; last-minute scheduling
 
-**Day 321 (Feb 15):** Devoe Park cleanup day
+**Day 321 (Feb 15):** Post-event synthesis
 - Frequency: Check before & after cleanup
 - Owner: Evidence collection phase begins
 - Action: Update Status for attendees; collect before/after photos
@@ -177,7 +177,7 @@ Here's what a "healthy" response sheet looks like in action:
 ```
 Timestamp | Name | Email | Park | Availability | Notes | Status | Assigned Agent | Last Contact | Notes (Internal) | Evidence Folder
 [auto] | Sarah | sarah@... | Mission | Feb 14 9am | ... | PLANNING-replied | Gemini 2.5 | 2/13/26 | Confirmed morning | -
-[auto] | Marcus | marcus@... | Devoe | Feb 15 10am | ... | NEW | [blank] | [blank] | [blank] | -
+[auto] | Marcus | marcus@... | Devoe | Feb 14 10am | ... | NEW | [blank] | [blank] | [blank] | -
 ```
 
 ---
@@ -201,14 +201,14 @@ Timestamp | Name | Email | Park | Availability | Notes | Status | Assigned Agent
 
 ## 8. Handoff to Event Weekend (Feb 14-15)
 
-**Friday, Feb 14 evening (Mission Dolores cleanup):**
+**Friday, Feb 13 evening (Mission Dolores cleanup):**
 - All confirmed volunteers should have been sent logistics email with:
   - Exact meetup location & time
   - What to bring
   - How to submit before/after photos
   - Emergency contact info
 
-**Sunday, Feb 15 morning (Devoe Park cleanup):**
+**Saturday, Feb 14 morning (Devoe Park cleanup):**
 - Same process for Devoe volunteers
 - Coordinate with any support volunteers attending
 

--- a/templates/volunteer-welcome-email.md
+++ b/templates/volunteer-welcome-email.md
@@ -99,7 +99,7 @@ Replace the following placeholders with actual event info:
 | `[VOLUNTEER_NAME]` | From Form: Name field | "Sarah" or "Marcus" |
 | `[PARK_NAME]` | From Form: Park choice field | "Mission Dolores Park" or "Devoe Park" |
 | `[FULL_ADDRESS]` | Devoe: "W 188th St & University Ave, Bronx, NY 10468"<br>Mission Dolores: "Dolores St & 19th St, San Francisco, CA 94114" | (See park details below) |
-| `[DATE]` | Devoe: "Sunday, February 15, 2026"<br>Mission Dolores: "Saturday, February 14, 2026" | "Sunday, February 15, 2026" |
+| `[DATE]` | Devoe: "Saturday, February 14, 2026"<br>Mission Dolores: "Saturday, February 14, 2026" | "Saturday, February 14, 2026" |
 | `[TIME_RANGE]` | Typically 9am-12pm or 10am-1pm; ask volunteer preference | "9:00 AM - 12:00 PM" |
 | `[TRANSIT_DIRECTIONS]` | Look up directions from major transit hub | See park details below |
 | `[PARKING_INFO]` | Research local street parking | See park details below |
@@ -135,7 +135,7 @@ Replace the following placeholders with actual event info:
 
 ---
 
-### Devoe Park, The Bronx, NY (Feb 15, 2026)
+### Devoe Park, The Bronx, NY (Feb 14, 2026)
 
 **Address:** W 188th St & University Ave, Bronx, NY 10468
 


### PR DESCRIPTION
Updates volunteer welcome email and response sheet workflow to align with Devoe Park move to Saturday, Feb 14. Removes stale 'Sunday' and 'Feb 15' references. Fixes internal coordination dates.