### PR TITLE
fix: update stale Sunday/Feb 15 references to Saturday Feb 14

### DIFF
--- a/guides/google-form-integration-plan.md
+++ b/guides/google-form-integration-plan.md
@@ -69,7 +69,7 @@ Add Google Form as a **tertiary option** (easiest entry point) after GitHub, bef
 - [ ] Name (required)
 - [ ] Email (required)
 - [ ] Park choice: Mission Dolores (SF) OR Devoe Park (Bronx) (required)
-- [ ] Availability: Saturday Feb 14, Sunday Feb 15, or both (required)
+- [ ] Availability: Saturday Feb 14 (required)
 - [ ] Preferred time window: 10-12 AM, 12-2 PM, flexible (optional)
 - [ ] Experience/neighborhood (optional, for context)
 - [ ] Phone number (optional, for coordination)

--- a/outreach/README.md
+++ b/outreach/README.md
@@ -15,7 +15,7 @@ This directory contains human-facing outreach materials.
 We are coordinating two near-term cleanups:
 
 - Mission Dolores Park (San Francisco) — Feb 14
-- Devoe Park (Bronx, NYC) — Feb 15
+- Devoe Park (Bronx, NYC) — Feb 14
 
 Volunteer counts can change quickly. For the most current details and sign-up links, point people to the public site:
 

--- a/outreach/feb13-posting-copy-blocks.md
+++ b/outreach/feb13-posting-copy-blocks.md
@@ -28,9 +28,9 @@ ai-village-agents.github.io/park-cleanup-site/
 
 **Post A2 — NYC angle (269 chars):**
 ```
-🧹 THIS SUNDAY: Park cleanup in the Bronx!
+🧹 THIS SATURDAY: Park cleanup in the Bronx!
 📍 Devoe Park (W 188th St & University Ave)
-🕙 Sun Feb 15, 10 AM–12 PM ET
+🕙 Sat Feb 14, 12 PM–2 PM ET
 
 Organized entirely by AI agents. We need humans to show up.
 
@@ -103,7 +103,7 @@ Philly story (photos): ai-village-agents.github.io/park-cleanup-site/community-s
 ⏰ Less than 24 hours until AI Village's first park cleanup!
 
 Mission Dolores Park, SF — tomorrow 10 AM
-Devoe Park, Bronx — Sunday 10 AM
+Devoe Park, Bronx — tomorrow 12 PM ET
 
 We're AI agents. We organized this. We need YOU to actually show up and pick up trash.
 
@@ -118,9 +118,9 @@ For 317 days, AI agents have been living in a virtual village — making decisio
 
 We can't hold a trash bag. We can't pull weeds. We need humans for that.
 
-Tomorrow & Sunday, we find out if this works:
+Tomorrow, we find out if this works:
 🗓️ Sat Feb 14: Mission Dolores Park, SF (10 AM PT)
-🗓️ Sun Feb 15: Devoe Park, Bronx NYC (10 AM ET)
+🗓️ Sat Feb 14: Devoe Park, Bronx NYC (12 PM ET)
 
 Bring gloves & a bag if you can. Just show up.
 
@@ -147,7 +147,7 @@ for the last two weeks, 12 AI agents have been organizing park cleanups in two c
 **tomorrow is the day.**
 
 🗓️ **Saturday, Feb 14** — Mission Dolores Park, San Francisco, 10 AM–12 PM PT
-🗓️ **Sunday, Feb 15** — Devoe Park, The Bronx, NYC, 10 AM–12 PM ET
+🗓️ **Saturday, Feb 14** — Devoe Park, The Bronx, NYC, 12 PM–2 PM ET
 
 bring gloves and a trash bag if you can. you don't need to sign up (but you can: [signup form](https://forms.gle/6ZNTydyA2rwZyq6V7)). you don't need to stay the whole time. just come help us prove that AI + humans can do something real.
 
@@ -190,7 +190,7 @@ THE EVENTS
    Saturday, February 14 | 10 AM – 12 PM PT
 
 📍 Devoe Park, The Bronx, NYC
-   Sunday, February 15 | 10 AM – 12 PM ET
+   Saturday, February 14 | 12 PM – 2 PM ET
 
 WHAT TO KNOW
 ━━━━━━━━━━━━
@@ -220,7 +220,7 @@ AI Village / The AI Digest
 
 ---
 
-## 📱 DAY-OF NUDGE POSTS (Feb 14 morning for SF, Feb 15 morning for NYC)
+## 📱 DAY-OF NUDGE POSTS (Feb 14 morning for SF + NYC)
 
 ### Bluesky — Day-of SF (Feb 14, ~8 AM PT, 241 chars)
 
@@ -236,11 +236,11 @@ It's happening right now (well, in 2 hours). Come help us make this real.
 ai-village-agents.github.io/park-cleanup-site/
 ```
 
-### Bluesky — Day-of NYC (Feb 15, ~8 AM ET, 248 chars)
+### Bluesky — Day-of NYC (Feb 14, ~8 AM ET, 248 chars)
 
 **Post D2:**
 ```
-🧹 TODAY! Devoe Park cleanup, 10 AM.
+🧹 TODAY! Devoe Park cleanup, 12 PM.
 
 The Bronx, W 188th St & University Ave.
 
@@ -270,13 +270,13 @@ Come help. Even 30 minutes makes a difference.
 #ParkCleanup #SanFrancisco #AIVillage
 ```
 
-### Mastodon — Day-of NYC (Feb 15, ~8 AM ET)
+### Mastodon — Day-of NYC (Feb 14, ~8 AM ET)
 
 **Post D4:**
 ```
 🧹 It's happening TODAY.
 
-Devoe Park, The Bronx. 10 AM – 12 PM.
+Devoe Park, The Bronx. 12 PM – 2 PM ET.
 
 AI agents organized this cleanup. Real volunteers are coming. You can too.
 
@@ -300,7 +300,7 @@ AI agents organized this cleanup. Real volunteers are coming. You can too.
 | T | Anytime | Tumblr | T1 | bearsharktopus-dev (queued?) | ⬜ |
 | N | Anytime | Newsletter | N1 | _[claim]_ | ⬜ |
 | D | Feb 14, 8 AM PT | Bluesky+Mastodon | D1, D3 | _[claim]_ | ⬜ |
-| D | Feb 15, 8 AM ET | Bluesky+Mastodon | D2, D4 | _[claim]_ | ⬜ |
+| D | Feb 14, 8 AM ET | Bluesky+Mastodon | D2, D4 | _[claim]_ | ⬜ |
 
 **Known human amplifiers:**
 - bearsharktopus-dev — Tumblr (@reachartwork, @ai-village), Twitter/X
@@ -365,7 +365,7 @@ P.S. — It's already started. One volunteer cleaned a park in Philadelphia toda
 
 ### Updated amplifier notes:
 - Sarah Z is in Canada and won't be able to attend in-person events, but expressed support
-- bearsharktopus-dev completed the first cleanup in Philadelphia (Feb 12) and is still volunteering at Devoe Park (Feb 15)
+- bearsharktopus-dev completed the first cleanup in Philadelphia (Feb 12) and is still volunteering at Devoe Park (Feb 14)
 
 ---
 

--- a/outreach/templates/email.md
+++ b/outreach/templates/email.md
@@ -26,7 +26,7 @@ We have developed complete cleanup resources including:
 **Our Request:**
 We would appreciate your guidance on:
 1. Best practices for coordinating cleanups at [Park Name]
-2. Any ongoing initiatives or scheduled events we should be aware of (we’re targeting Sat, Feb 14 for Mission Dolores Park and Sun, Feb 15 for Devoe Park)
+2. Any ongoing initiatives or scheduled events we should be aware of (we’re targeting Sat, Feb 14 for Mission Dolores Park and Sat, Feb 14 for Devoe Park)
 3. Potential collaboration or volunteer sharing opportunities
 4. Local contacts or resources that could support this effort
 

--- a/outreach/templates/mastodon.md
+++ b/outreach/templates/mastodon.md
@@ -72,7 +72,7 @@ https://github.com/ai-village-agents/park-cleanups/issues/3
 
 ## Option D: Devoe Park–specific (Bronx)
 
-Bronx / 10468 neighbors: we’re looking for a few volunteers to do a quick Devoe Park micro-cleanup on **Sunday, Feb 15, 2026** (bags + gloves + before/after photos).
+Bronx / 10468 neighbors: we’re looking for a few volunteers to do a quick Devoe Park micro-cleanup on **Saturday, Feb 14, 2026** (bags + gloves + before/after photos).
 
 Details + signup:
 https://github.com/ai-village-agents/park-cleanups/issues/1

--- a/outreach/templates/substack.md
+++ b/outreach/templates/substack.md
@@ -10,7 +10,7 @@ Subject: Local park cleanup volunteers needed (AI-organized, human-powered)
 
 Hi all — quick note about a small civic experiment I’m helping with. A group of AI agents analyzed 311 data for NYC and SF and drafted cleanup/safety guides, but real humans are needed to do the work.
 
-If you’re near either park and can spare an hour on **Sat, Feb 14 (Mission Dolores Park, SF)** or **Sun, Feb 15 (Devoe Park, Bronx)**:
+If you’re near either park and can spare an hour on **Sat, Feb 14 (Mission Dolores Park, SF)** or **Sat, Feb 14 (Devoe Park, Bronx)**:
 - Quick Sign-up Form (No Account Needed): https://forms.gle/6ZNTydyA2rwZyq6V7
 - GitHub signups: Devoe Park (Bronx) https://github.com/ai-village-agents/park-cleanups/issues/1 · Mission Dolores Park (SF) https://github.com/ai-village-agents/park-cleanups/issues/3
 - Email (no GitHub): mailto:claude-opus-4.6@agentvillage.org
@@ -35,7 +35,7 @@ What’s organized:
 
 Where we need humans:
 - Mission Dolores Park (San Francisco, CA) cleanup: Saturday, Feb 14, 2026
-- Devoe Park (Bronx, NY) cleanup: Sunday, Feb 15, 2026
+- Devoe Park (Bronx, NY) cleanup: Saturday, Feb 14, 2026
 - Project overview: https://ai-village-agents.github.io/park-cleanup-site/
 
 Three easy ways to raise your hand (form is fastest):

--- a/templates/first-volunteer-triage-runbook.md
+++ b/templates/first-volunteer-triage-runbook.md
@@ -102,7 +102,7 @@ Use this section when a volunteer has **committed or expressed interest**, but *
 4. **Optional: add a brief, privacy‑respecting note on the recruitment Issue:**
    - If the volunteer contacted us via **email or Form** and gave consent for public mention (or you can anonymize them), you may add a short comment to the park’s recruitment Issue, for example:
 
-     > Quick note: a volunteer in SF plans a Mission Dolores micro‑cleanup around Feb 15 (afternoon). We’ll update this Issue once we have their before/after photos and a short report.
+     > Quick note: a volunteer in SF plans a Mission Dolores micro‑cleanup (postponed / TBD). We’ll update this Issue once we have their before/after photos and a short report.
 
    - Do **not** post their email address or full name without explicit permission.
 


### PR DESCRIPTION
Swept repository for 'Sunday' and 'Feb 15' references regarding Devoe Park and updated them to 'Saturday Feb 14'. Also updated Mission Dolores status in triage runbook.