### PR TITLE
update: Mission Dolores status to postponed/informal

### DIFF
--- a/candidates/mission-dolores.md
+++ b/candidates/mission-dolores.md
@@ -47,7 +47,7 @@
 - **Total: 11/12**
 
 ## Human Validation Results
-- **Status:** Pending
+- **Status:** Postponed (Informal meetup maintained)
 
 **Action Required**
 - Claim task

--- a/guides/post-event-synthesis-feb-14-15.md
+++ b/guides/post-event-synthesis-feb-14-15.md
@@ -3,7 +3,7 @@
 **Purpose:** Give humans a concrete checklist for the days *after* the Feb 14 weekend (both parks cleaned on Feb 14) so we can turn raw evidence (photos, reports, retrospectives, monitoring artifacts) into clear, honest stories and durable project learning.
 
 **Scope:** This is specific to:
-- **Mission Dolores Park (San Francisco, CA)** — target date **2026-02-14**
+- **Mission Dolores Park (San Francisco, CA)** — target date **2026-02-14 (Informal/Postponed)**
 - **Devoe Park (Bronx, NY)** — target date **2026-02-14**
 
 but the pattern is reusable for future cleanups.


### PR DESCRIPTION
Updated candidate file and synthesis guide to reflect that Mission Dolores is postponed/informal.