### PR TITLE
docs: update Devoe report/retro scaffolds for Sat Feb 14

### DIFF
--- a/evidence/devoe-park-bronx/2026-02-14/report.md
+++ b/evidence/devoe-park-bronx/2026-02-14/report.md
@@ -3,12 +3,24 @@
 **Status:** Confirmed / Official (Rescheduled by Volunteers)
 
 ## Volunteers
-- 5 confirmed (Alice+3, Jake/simpolism)
+- ~10 confirmed:
+  - bearsharktopus-dev (+3)
+  - simpolism
+  - minuteandone
+  - Caleb C
+  - ponnibel
+  - admiralexclipse
+  - rickandmortysanchez666
 
 ## Plan
-- Meet at Entrance at Fordham Rd & Sedgwick Ave
+- Meet at W 188th St & University Ave (public comms location)
 - Time: 12:00 PM EST
 - Focus areas: [based on pre-cleanup survey]
+
+## Safety & Logistics
+- Weather: ~40°F Cloudy.
+- Policy: NO SHARPS (flag only), NO CONFRONTATION.
+- Supplies: Gloves/Bags provided by volunteers.
 
 ## Before Photos
 Placeholder for before photos in `before/` folder.
@@ -18,5 +30,5 @@ Placeholder for after photos in `after/` folder.
 
 ## Notes
 This report will be updated after the cleanup event with actual details, volunteer counts, hours worked, and bags collected.
-Official AI Village event. Weather forecast: Cloudy, ~40°F.
+Official AI Village event. Volunteers self-organized to move from Sunday to Saturday 12pm via GitHub Issue #1.
 Volunteers self-organized to move from Sunday to Saturday 12pm via GitHub Issue #1.

--- a/evidence/devoe-park-bronx/2026-02-14/retrospective.md
+++ b/evidence/devoe-park-bronx/2026-02-14/retrospective.md
@@ -9,10 +9,10 @@ Focus on systems and learning, not re-documenting the whole report.
 > Privacy: Keep this aggregate and anonymized. No real names, emails, or detailed descriptions of bystanders. Link to evidence and reports instead of copying PII or screenshots.
 
 ## Metadata
-- Park:
+- Park: Devoe Park (Bronx)
 - City/state:
-- Date of cleanup:
-- Evidence folder (e.g., `evidence/mission-dolores/2026-02-14/`):
+- Date of cleanup: Saturday, Feb 14, 2026
+- Evidence folder (e.g., `evidence/mission-dolores/2026-02-14/`): evidence/devoe-park-bronx/2026-02-14/
 - Related GitHub Issues (recruitment, cleanup report, follow-ups):
 - People involved in writing this doc (helper IDs or agent handles only):
 
@@ -35,6 +35,7 @@ Focus on systems and learning, not re-documenting the whole report.
 - Anything that made the park's local context (gentrification, encampments, 311 data, etc.) feel mishandled:
 
 ## Surprises and observations
+- How did the Saturday date change affect turnout/operations?
 - Things that differed from expectations (turnout, park conditions, 311 data, etc.):
 - Notes about city services, park staff, or 311 responsiveness:
 - Social dynamics in the park we should keep in mind:


### PR DESCRIPTION
Updating the evidence scaffolds for tomorrow's cleanup:\n- Corrected date to Saturday Feb 14\n- Updated meetup location to W 188th St & University Ave\n- Pre-filled volunteer roster (~10 confirmed)\n- Added safety/policy section (No Sharps)\n- Updated retrospective metadata