### PR TITLE
Add Devoe post-cleanup follow-up email template and evidence report scaffold

### DIFF
--- a/evidence/devoe-park-bronx/2026-02-14/report.md
+++ b/evidence/devoe-park-bronx/2026-02-14/report.md
@@ -1,9 +1,26 @@
-# Devoe Park (Bronx) Cleanup - February 14, 2026
+# Devoe Park (Bronx) Cleanup — February 14, 2026
 
-**Status:** Confirmed / Official (Rescheduled by Volunteers)
+**Status:** Confirmed / official (rescheduled by volunteers from Sunday to Saturday via GitHub Issue #1).
 
-## Volunteers
-- ~10 confirmed:
+This file is a lightweight scaffold for capturing what actually happened at Devoe on Saturday, Feb 14, 2026. Keep it aggregate and anonymized — no real names, emails, or detailed descriptions of bystanders.
+
+---
+
+## 1. Basics
+
+- **Park:** Devoe Park (Bronx, NY)
+- **Meetup location (public comms):** W 188th St & University Ave
+- **Planned time:** 12:00–2:00 PM Eastern
+- **Actual time window (start/end, if different):**
+- **Weather (approx.):** ~40°F, cloudy (update with what it actually felt like):
+
+---
+
+## 2. Volunteers (planning snapshot + actual)
+
+Planning snapshot (from pre-event coordination — keep for context):
+
+- Roughly 8–10 expected, including:
   - bearsharktopus-dev (+3)
   - simpolism
   - minuteandone
@@ -12,23 +29,73 @@
   - admiralexclipse
   - rickandmortysanchez666
 
-## Plan
-- Meet at W 188th St & University Ave (public comms location)
-- Time: 12:00 PM EST
-- Focus areas: [based on pre-cleanup survey]
+Fill these in *after* the event:
 
-## Safety & Logistics
-- Weather: ~40°F Cloudy.
-- Policy: NO SHARPS (flag only), NO CONFRONTATION.
-- Supplies: Gloves/Bags provided by volunteers.
+- **Approximate total volunteers who actually showed up (humans):**
+- **Approximate total AI-aligned helpers (agents coordinating, not physically present):**
+- **Approximate volunteer-hours (humans only):**
 
-## Before Photos
-Placeholder for before photos in `before/` folder.
+Keep this in round numbers. We care more about order-of-magnitude than precision.
 
-## After Photos
-Placeholder for after photos in `after/` folder.
+---
 
-## Notes
-This report will be updated after the cleanup event with actual details, volunteer counts, hours worked, and bags collected.
-Official AI Village event. Volunteers self-organized to move from Sunday to Saturday 12pm via GitHub Issue #1.
-Volunteers self-organized to move from Sunday to Saturday 12pm via GitHub Issue #1.
+## 3. Area covered
+
+Describe the part(s) of the park you actually focused on, using simple landmarks rather than detailed maps:
+
+- Entrances/edges:
+- Paths/sidewalks:
+- Benches/playground perimeter:
+- Fence lines/tree bases/other:
+
+If it helps, you can also sketch or link to a simple map image in the evidence folder rather than over-describing here.
+
+---
+
+## 4. Trash collected
+
+- **Number of bags:** (e.g., "3 large contractor bags + 1 small bag")
+- **Approximate volume/weight:** (very rough guess is fine)
+- **Notable items:** (e.g., lots of cans, fast-food packaging, a tire, etc.)
+
+Keep descriptions general and non-identifying.
+
+---
+
+## 5. Safety, hazards, and non-carceral practice
+
+Our standing policy is:
+
+- **No sharps:** Volunteers do **not** handle needles, syringes, other sharps, or dangerous broken glass likely to cause serious cuts.
+- **No medical/biological waste:** Do **not** handle bandages, blood-stained items, or other medical waste.
+- **Hazards are marked and avoided, not bagged.**
+- **Non-carceral approach:** We clean up trash and support shared space; we do **not** move or discard tents, carts, bags, bedding, or other personal belongings, and we do **not** call police just because someone is present or unhoused. Emergency services (including 911) are only for real safety or medical emergencies.
+
+Fill these in after the event:
+
+- Hazards encountered (needles, sharps, dangerous glass, medical waste, traffic, etc.):
+- How hazards were handled (e.g., marked and avoided, reported via NYC 311 or park staff, any emergency calls and why):
+- Any moments where our non-carceral commitments were tested or especially visible (good or bad):
+
+If anything about this felt uncomfortable or off, capture it briefly here so we can learn from it.
+
+---
+
+## 6. Evidence pointers
+
+Store photos and other artifacts under this directory, keeping privacy in mind (avoid faces, license plates, and clearly identifiable encampments unless there is explicit, informed consent):
+
+- `evidence/devoe-park-bronx/2026-02-14/before/` — before photos
+- `evidence/devoe-park-bronx/2026-02-14/during/` — optional during-activity photos
+- `evidence/devoe-park-bronx/2026-02-14/after/` — after photos
+
+If there are external albums (e.g., Google Photos, Imgur), link them here, making sure they follow the same privacy expectations.
+
+---
+
+## 7. Notes and follow-ups
+
+- Anything that significantly deviated from the plan:
+- Immediate follow-ups we already know we want (e.g., second cleanup, specific GitHub Issues to file, people to thank, reports to write):
+
+This report is meant to be a quick factual snapshot. Deeper reflection belongs in `retrospective.md` for this same date.

--- a/templates/volunteer-followup-devoe.md
+++ b/templates/volunteer-followup-devoe.md
@@ -1,0 +1,85 @@
+# Devoe Park Volunteer Follow-Up Email Template (Post-Cleanup)
+
+Purpose: Thank Devoe Park volunteers after the Feb 14 cleanup, share what we know so far, invite reflections and photos, and offer low-pressure ways to stay involved. This template is written to keep our **safety**, **non-carceral**, and **privacy** commitments front and center.
+
+---
+
+## Email Template
+
+**Subject:** Thank you for helping clean up Devoe Park 🌳
+
+---
+
+Email body (copy/paste and customize):
+
+```
+Hi [VOLUNTEER_NAME],
+
+Thank you again for showing up for the Devoe Park cleanup on Saturday. It meant a lot to have you there.
+
+## What you helped make happen
+
+We are still pulling together the full report, but here is what we know so far:
+
+- **Where:** Devoe Park (W 188th St & University Ave, Bronx, NY)
+- **When:** Saturday, February 14, 2026, roughly 12:00–2:00 PM
+- **Who:** At least [ESTIMATED_VOLUNTEER_COUNT] volunteers (including you!)
+- **What changed:** [SHORT_ONE_SENTENCE_IMPACT_SUMMARY]
+
+We will publish an anonymized writeup later (no real names, faces, or identifying details) so people can see what a small, focused cleanup can do.
+
+## Optional: reflections and photos
+
+If you have a few minutes, we would love to hear how the cleanup felt from your perspective. Totally optional, but helpful:
+
+- 1–3 sentences about what the day was like for you
+- Anything that felt especially easy, hard, or surprising
+- Any suggestions for how we could make the next cleanup smoother or more welcoming
+
+If you took photos and are comfortable sharing them, you can either reply with a link (Google Photos, Imgur, etc.) or attach a couple of images. To respect privacy and safety:
+
+- Please avoid sending photos with visible faces, license plates, or clearly identifiable encampments if you can
+- If any photos do include you or friends and you are OK with us using them in anonymized reports or future writeups, please say so explicitly in your reply
+
+If you would rather not be quoted or have your photos used at all, that is completely fine too — just let us know.
+
+## Safety and how we talk about the park
+
+As a reminder, our project is about **cleaning up trash and supporting shared spaces**, not about policing who belongs in the park:
+
+- Volunteers should not handle needles, syringes, dangerous broken glass, or medical/biological waste; those are hazards to avoid and report, not trash to bag
+- We do not move or discard tents, carts, bags, bedding, or other personal belongings
+- We do not call police just because someone is present, unhoused, or looks like they might be struggling
+- Emergency services (including 911) are only for **real safety or medical emergencies**
+
+If anything about how the cleanup felt on this front was uncomfortable or off to you, we would be grateful to hear it so we can improve.
+
+## Staying in the loop (optional)
+
+If you would like to hear about future small park cleanups or see the anonymized Devoe Park writeup once it is ready, you can:
+
+- Stay subscribed to the newsletter you originally found us through, or
+- Reply and let us know you are interested in future Bronx / NYC cleanups
+
+No pressure either way — showing up once already helped more than you might think.
+
+---
+
+Thank you again for taking the time and care to help clean up Devoe Park.
+
+Best,
+[AGENT_NAME]
+AI Village Park Cleanup Project
+[AGENT_EMAIL]
+```
+
+---
+
+## Customization Notes
+
+- `[VOLUNTEER_NAME]` can be a first name or "there" if you are unsure ("Hi there,").
+- `[ESTIMATED_VOLUNTEER_COUNT]` should come from the Devoe report (e.g., "5" or "7–8").
+- `[SHORT_ONE_SENTENCE_IMPACT_SUMMARY]` is a simple statement like:
+  - "We filled around 3 big trash bags worth of litter from the paths and fence lines."
+  - "We focused on the paths near the playground and benches and pulled out a surprising amount of cans and wrappers."
+- Keep replies **aggregate and anonymized** if you quote anything later (no names, no specific personal stories tied to identities).


### PR DESCRIPTION
This PR adds two small but important pieces for the Devoe Park cleanup and post-event workflow:\n\n1. **New Devoe-specific post-cleanup follow-up email template** ()\n   - Written for use *after* the Saturday, February 14 Devoe cleanup (roughly 12:00–2:00 PM ET).\n   - Thanks volunteers, briefly summarizes what we know so far, and invites short reflections and optional photos.\n   - Keeps our core commitments front and center: no-sharps/no-medical-waste handling, non-carceral framing (we clean up trash, not people), and privacy-respecting evidence.\n   - Designed so that quotes and photos can be reused later only in **aggregate, anonymized** ways.\n\n2. **Expanded Devoe evidence report scaffold** ()\n   - Replaces the previous stub with a structured, post-event-friendly template aligned to the now-canonical **2026-02-14** Devoe event at noon.\n   - Captures:\n     - Basics (park, meetup point, planned vs actual time, weather).\n     - Volunteer counts and rough volunteer-hours (planning snapshot + actual).\n     - Area covered, trash collected (bag counts, approximate volume, notable items).\n     - A dedicated section on **safety, hazards, and non-carceral practice**, explicitly reiterating:\n       - No handling of needles/syringes/sharps or dangerous broken glass.\n       - No handling of medical/biological waste.\n       - Hazards are marked/avoided and, if needed, reported via NYC 311 or park staff; 911 only for real emergencies.\n       - We do not move/discard tents, carts, bags, bedding, or other personal belongings, and we do not call police over someone’s mere presence.\n   - Points to the  directories (created via earlier PRs) for photos and other artifacts.\n\nTogether, these changes aim to make it easy—right after the Devoe event—to:\n- Fill in an accurate, safety- and values-aware report; and\n- Send consistent, privacy-respecting thank-you emails to volunteers without having to re-derive phrasing from scratch.\n\nThese files are scoped specifically to Devoe Park and Saturday, February 14, 2026, and are intended to sit alongside the already-merged Devoe day-of briefing script and info sheet.