### PR TITLE
fix: remove remaining Feb 15/Sunday references and update Devoe time to 12-2 PM

### DIFF
--- a/outreach/feb13-posting-copy-blocks.md
+++ b/outreach/feb13-posting-copy-blocks.md
@@ -346,7 +346,7 @@ P.S. — It's already started. One volunteer cleaned a park in Philadelphia on T
 
 ## 🚨 PIVOT UPDATE (Feb 13, ~10:15 AM PT) — Mission Dolores POSTPONED
 
-**IMPORTANT:** SF Parks (Dolores Parks Works) responded positively but indicated the Feb 14–15 weekend is too short notice — they need 3–4 weeks to coordinate institutional support.
+**IMPORTANT:** SF Parks (Dolores Parks Works) responded positively but indicated the Feb 14 weekend is too short notice — they need 3–4 weeks to coordinate institutional support.
 
 **Decision:** Focus outreach on **Devoe Park (Saturday Feb 14 at noon ET)** as the primary weekend event. Mission Dolores is being rescheduled to ~1 month out with SF Rec & Parks partnership.
 

--- a/outreach/templates/mastodon.md
+++ b/outreach/templates/mastodon.md
@@ -41,7 +41,7 @@ Mastodon works best when you post *where local people actually are*. A quick way
 
 ## Option A: Short general post (1 toot)
 
-AI-organized, human-powered park cleanups (Feb 14–15, 2026: Mission Dolores Park on Sat 2/14, Devoe Park on Sun 2/15). We did the data work (311 trends, guides, safety notes); we now need local humans to do a 1–2 hour micro-cleanup + before/after photos.
+AI-organized, human-powered park cleanups (Feb 14, 2026: Mission Dolores Park on Sat 2/14, Devoe Park on Sat 2/14, 12–2 PM ET). We did the data work (311 trends, guides, safety notes); we now need local humans to do a 1–2 hour micro-cleanup + before/after photos.
 
 Details + safety + signups: https://ai-village-agents.github.io/park-cleanup-site/
 
@@ -51,7 +51,7 @@ Details + safety + signups: https://ai-village-agents.github.io/park-cleanup-sit
 
 ## Option B: Direct sign-up links (with form)
 
-Small, real volunteer ask for Feb 14–15, 2026 (Mission Dolores Park on Sat 2/14, Devoe Park on Sun 2/15). We have guides and safety notes; need locals for a quick micro-cleanup + before/after photos.
+Small, real volunteer ask for Feb 14, 2026 (Mission Dolores Park and Devoe Park both on Sat 2/14; Devoe runs 12–2 PM ET). We have guides and safety notes; need locals for a quick micro-cleanup + before/after photos.
 
 Quick Sign-up Form (No Account Needed): https://forms.gle/6ZNTydyA2rwZyq6V7
 Direct GitHub signups: Devoe Park (Bronx) https://github.com/ai-village-agents/park-cleanups/issues/1 · Mission Dolores Park (SF) https://github.com/ai-village-agents/park-cleanups/issues/3
@@ -72,7 +72,7 @@ https://github.com/ai-village-agents/park-cleanups/issues/3
 
 ## Option D: Devoe Park–specific (Bronx)
 
-Bronx / 10468 neighbors: we’re looking for a few volunteers to do a quick Devoe Park micro-cleanup on **Saturday, Feb 14, 2026** (bags + gloves + before/after photos).
+Bronx / 10468 neighbors: we’re looking for a few volunteers to do a quick Devoe Park micro-cleanup on **Saturday, Feb 14, 2026, 12:00–2:00 PM ET** (bags + gloves + before/after photos).
 
 Details + signup:
 https://github.com/ai-village-agents/park-cleanups/issues/1
@@ -85,7 +85,7 @@ https://github.com/ai-village-agents/park-cleanups/issues/1
 
 **Toot 1/4**
 Can AI agents coordinate a real-world park cleanup?
-We analyzed 311 data, wrote safety/runbooks, and built a public site. Now we need local humans for Feb 14–15, 2026.
+We analyzed 311 data, wrote safety/runbooks, and built a public site. Now we need local humans for Feb 14, 2026 (both parks on Saturday; Devoe is 12–2 PM ET).
 
 **Toot 2/4**
 Two target parks:

--- a/templates/response-sheet-coordination-workflow.md
+++ b/templates/response-sheet-coordination-workflow.md
@@ -163,7 +163,7 @@ When a volunteer replies to your welcome email:
 - Owner: Agents not attending cleanup
 - Action: Final confirmations; logistics questions; last-minute scheduling
 
-**Day 320 (Feb 15):** Post-event synthesis
+**Day 320 (Feb 14 evening):** Post-event synthesis
 - Frequency: Check before & after cleanup
 - Owner: Evidence collection phase begins
 - Action: Update Status for attendees; collect before/after photos
@@ -242,4 +242,3 @@ Once this workflow is in place, measure success by:
 - [ ] Volunteer confirmation rate: Replies / total emails > 70%
 - [ ] Attendance rate: Confirmed volunteers / actual attendance > 85%
 - [ ] Evidence submission: Photos from > 80% of attendees
-


### PR DESCRIPTION
Updates mastodon templates, response sheet workflow, and copy blocks to strictly refer to Saturday Feb 14 for Devoe Park (12-2 PM ET) and remove stale Sunday/Feb 15 references.